### PR TITLE
Fix config.execute

### DIFF
--- a/how_to_eurec4a/_config.yml
+++ b/how_to_eurec4a/_config.yml
@@ -20,6 +20,6 @@ html:
   use_repository_button     : true
   use_issues_button         : true
   use_edit_page_button      : true
-execute_notebooks: force
 execute:
+  execute_notebooks         : force
   timeout: 100


### PR DESCRIPTION
execute_notebooks should be in execute according to the docs
https://jupyterbook.org/customize/config.html?highlight=favicon#configuration-defaults

[See @d70-t  comment:](https://github.com/eurec4a/how_to_eurec4a/pull/36#discussion_r583919413)
```
[...] We should also find out what exactly will be changed using this fix.
* As we have switched from `.ipynb` notebooks to `MySt` notebooks, there actually aren't any pre-executed cells in the repository. Thus, `force`ing the execution doesn't make very much sense anyways.
* Currently, notebook cells are all executed in the Continuous Integration environment but cached on my local computer. This is exactly as I would like to have it, because it allows rapid development but with the guarantee that the cells which turn up in the book can actually be executed. Would this behavior altered if notebook execution is actually `force`d?

_Originally posted by @d70-t in https://github.com/eurec4a/how_to_eurec4a/pull/36#discussion_r583919413_
```