### PR TITLE
Some cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build
 .ipynb_checkpoints
 *.swp
+.DS_Store

--- a/how_to_eurec4a/bacardi.md
+++ b/how_to_eurec4a/bacardi.md
@@ -35,7 +35,9 @@ list(cat.HALO.BACARDI)
 
 * We can further specify the platform, instrument, if applicable dataset level or variable name, and pass it on to dask.
 
-*Note: have a look at the attributes of the xarray dataset `ds` for all relevant information on the dataset, such as author, contact, or citation infromation.*
+```{note}
+Have a look at the attributes of the xarray dataset `ds` for all relevant information on the dataset, such as author, contact, or citation infromation.
+```
 
 ```{code-cell} ipython3
 ds = cat.HALO.BACARDI.irradiances['HALO-0205'].to_dask()

--- a/how_to_eurec4a/bacardi.md
+++ b/how_to_eurec4a/bacardi.md
@@ -66,7 +66,7 @@ ax2.set_prop_cycle(color=['grey', 'skyblue', 'darkblue'])
 for var in ['F_down_solar_sim', 'F_down_solar_diff', 'F_down_solar']:
     ds[var].plot(ax=ax2, label= var)
 ax2.legend()
-ax2.set_ylabel('downward solar irradiance / Wm$^{-2}$')
+ax2.set_ylabel('downward solar irradiance / Wm$^{-2}$');
 ```
 
 The attitude correction of downward solar irradiance does not account for the present cloud situation above HALO. Instead, two data sets, one assuming cloud-free and one assuming overcast (diffuse illumination) conditions, are provided. Depending on the application, the user needs to choose between both data sets. For the downward solar irradiance assuming cloud-free conditions, the data are filtered for turns of HALO, high roll and pitch angles. This filter is not applied for the data assuming overcast/diffuse conditions to provide the full data. However, data during turns of HALO need to be analysed with care. As shown in the example some artifical spikes due to turns are present in the data.
@@ -81,5 +81,5 @@ ds.F_down_solar.plot(ax=ax, color = 'darkblue')
 ax.set_ylabel('downward solar irradiance \n corrected for cloud-free conditions / Wm$^{-2}$', color = 'darkblue')
 ax2=ax.twinx()
 ds.sza.plot(ax=ax2, color = 'black')
-ax2.set_ylim(110,28)
+ax2.set_ylim(110,28);
 ```

--- a/how_to_eurec4a/bacardi.md
+++ b/how_to_eurec4a/bacardi.md
@@ -77,9 +77,10 @@ The wiggles originate from the about 200km change in location  and therewith sol
 
 ```{code-cell} ipython3
 fig, ax = plt.subplots()
-ds.F_down_solar.plot(ax=ax, color = 'darkblue')
-ax.set_ylabel('downward solar irradiance \n corrected for cloud-free conditions / Wm$^{-2}$', color = 'darkblue')
-ax2=ax.twinx()
-ds.sza.plot(ax=ax2, color = 'black')
-ax2.set_ylim(110,28);
+ds.F_down_solar.plot(ax=ax, color='darkblue')
+ax.set_ylabel('downward solar irradiance \n corrected for cloud-free conditions / Wm$^{-2}$',
+              color='darkblue')
+ax2 = ax.twinx()
+ds.sza.plot(ax=ax2, color='black')
+ax2.set_ylim(110, 28);
 ```

--- a/how_to_eurec4a/bacardi.md
+++ b/how_to_eurec4a/bacardi.md
@@ -17,10 +17,6 @@ The following script exemplifies the access and usage of the Broadband AirCrAft 
 
 The dataset is published under [Ehrlich et al. (2021)](https://doi.org/10.25326/160). If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
-```{code-cell} ipython3
-%pylab inline
-```
-
 ## Get data
 * To load the data we first load the EUREC4A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
 
@@ -55,9 +51,11 @@ The data from EUREC4A is of 10 Hz measurement frequency and corrected for dynami
 We plot the upward and downward irradiances in two panels.
 
 ```{code-cell} ipython3
-mpl.rcParams['font.size'] = 12
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.style.use(["./mplstyle/book", "./mplstyle/wide"])
 
-fig, (ax1, ax2) = plt.subplots(1,2, figsize=(16,6))
+fig, (ax1, ax2) = plt.subplots(1, 2)
 ax1.set_prop_cycle(color=['darkblue', 'red'])
 for var in ['F_up_solar', 'F_up_terrestrial']:
     ds[var].plot(ax=ax1,label= var)
@@ -69,10 +67,6 @@ for var in ['F_down_solar_sim', 'F_down_solar', 'F_down_solar_diff']:
     ds[var].plot(ax=ax2, label= var)
 ax2.legend()
 ax2.set_ylabel('downward solar irradiance / Wm$^{-2}$')
-
-for ax in [ax1, ax2]:
-    ax.spines['right'].set_visible(False)
-    ax.spines['top'].set_visible(False)
 ```
 
 The attitude correction of downward solar irradiance does not account for the present cloud situation above HALO. Instead, two data sets, one assuming cloud-free and one assuming overcast (diffuse illumination) conditions, are provided. Depending on the application, the user needs to choose between both data sets. For the downward solar irradiance assuming cloud-free conditions, the data are filtered for turns of HALO, high roll and pitch angles. This filter is not applied for the data assuming overcast/diffuse conditions to provide the full data. However, data during turns of HALO need to be analysed with care. As shown in the example some artifical spikes due to turns are present in the data.

--- a/how_to_eurec4a/bacardi.md
+++ b/how_to_eurec4a/bacardi.md
@@ -62,8 +62,8 @@ for var in ['F_up_solar', 'F_up_terrestrial']:
 ax1.legend()
 ax1.set_ylabel('upward solar and terrestrial irradiance / Wm$^{-2}$')
 
-ax2.set_prop_cycle(color=['grey', 'darkblue', 'skyblue'])
-for var in ['F_down_solar_sim', 'F_down_solar', 'F_down_solar_diff']:
+ax2.set_prop_cycle(color=['grey', 'skyblue', 'darkblue'])
+for var in ['F_down_solar_sim', 'F_down_solar_diff', 'F_down_solar']:
     ds[var].plot(ax=ax2, label= var)
 ax2.legend()
 ax2.set_ylabel('downward solar irradiance / Wm$^{-2}$')

--- a/how_to_eurec4a/bacardi.md
+++ b/how_to_eurec4a/bacardi.md
@@ -54,7 +54,9 @@ We plot the upward and downward irradiances in two panels.
 %matplotlib inline
 import matplotlib.pyplot as plt
 plt.style.use(["./mplstyle/book", "./mplstyle/wide"])
+```
 
+```{code-cell} ipython3
 fig, (ax1, ax2) = plt.subplots(1, 2)
 ax1.set_prop_cycle(color=['darkblue', 'red'])
 for var in ['F_up_solar', 'F_up_terrestrial']:

--- a/how_to_eurec4a/dropsondes.md
+++ b/how_to_eurec4a/dropsondes.md
@@ -40,7 +40,9 @@ list(cat)
 
 * We can funrther specify the platform, instrument, if applicable dataset level or variable name, and pass it on to dask.
 
-*Note: have a look at the attributes of the xarray dataset `ds` for all relevant information on the dataset, such as author, contact, or citation infromation.*
+```{note}
+Have a look at the attributes of the xarray dataset `ds` for all relevant information on the dataset, such as author, contact, or citation infromation.
+```
 
 ```{code-cell} ipython3
 ds = cat.dropsondes.JOANNE.level3.to_dask()
@@ -100,7 +102,10 @@ ds_sondes_first_circle_Feb05 = ds.isel(sounding=mask_sondes_first_circle_Feb05)
 
 ## Plots
 You can get a list of available variables in the dataset from `ds.variables.keys()`  
-*Note: fetching the data and displaying it might take a few seconds*
+
+```{note}
+fetching the data and displaying it might take a few seconds
+```
 
 ```{code-cell} ipython3
 import matplotlib as mpl

--- a/how_to_eurec4a/dropsondes.md
+++ b/how_to_eurec4a/dropsondes.md
@@ -119,16 +119,18 @@ The temperature profiles are colored according to their launch time, while relat
 
 ```{code-cell} ipython3
 def dt64_to_dt(dt64):
-    return datetime.datetime.utcfromtimestamp((dt64 - np.datetime64('1970-01-01T00:00:00'))
-                                              / np.timedelta64(1, 's'))
+    epoch = np.datetime64('1970-01-01T00:00:00')
+    second = np.timedelta64(1, 's')
+    return datetime.datetime.utcfromtimestamp(int((dt64 - epoch) / second))
 ```
 
 ```{code-cell} ipython3
 fig, (ax0, ax1) = plt.subplots(1, 2)
 
 y = ds_sondes_first_circle_Feb05.alt
+
 x0 = ds_sondes_first_circle_Feb05.ta
-ax0.set_prop_cycle(color=plt.get_cmap("viridis")(np.linspace(0, 1, len(dropsonde_ids))))
+ax0.set_prop_cycle(color=plt.cm.viridis(np.linspace(0, 1, len(dropsonde_ids))))
 ax0.plot(x0.T, y.data[:, np.newaxis])
 ax0.set_xlabel(f"{x0.long_name} / {x0.units}")
 ax0.set_ylabel(f"{y.name} / m")
@@ -154,8 +156,7 @@ None
 ### wind speed variations throughout February 5
 
 ```{code-cell} ipython3
-mask_sondes_Feb05 = [dt64_to_dt(t).date() == datetime.date(2020,2,5)
-                     for t in ds.launch_time.values]
+mask_sondes_Feb05 = ds.launch_time.astype("<M8[D]") == np.datetime64("2020-02-05")
 ds_sondes_Feb05 = ds.isel(sounding=mask_sondes_Feb05)
 ```
 

--- a/how_to_eurec4a/dropsondes.md
+++ b/how_to_eurec4a/dropsondes.md
@@ -112,6 +112,7 @@ plt.style.use("./mplstyle/book")
 fig, (ax0, ax1) = plt.subplots(1, 2)
 ds_sondes_first_circle_Feb05.ta.T.plot(ax=ax0, cmap="magma")
 ds_sondes_first_circle_Feb05.rh.T.plot(ax=ax1, cmap="BrBG")
+None
 ```
 
 ### Temperature and relative humidity profiles.
@@ -148,6 +149,7 @@ ax1.legend(ds_sondes_first_circle_Feb05.PW.values,
            title=ds_sondes_first_circle_Feb05.PW.standard_name)
 
 fig.suptitle('Dropsondes from 1st circle an February 5', fontsize=18)
+None
 ```
 
 ### wind speed variations throughout February 5
@@ -171,4 +173,5 @@ with plt.style.context("mplstyle/wide"):
     ax.set_yticks(yticks)
     ax.set_yticklabels(ds_sondes_Feb05.alt.values[yticks])
     ax.set_ylabel(f"{ds_sondes_Feb05.alt.name} / m")
+    None
 ```

--- a/how_to_eurec4a/dropsondes.md
+++ b/how_to_eurec4a/dropsondes.md
@@ -109,8 +109,8 @@ plt.style.use("./mplstyle/book")
 
 ```{code-cell} ipython3
 fig, (ax0, ax1) = plt.subplots(1, 2)
-ds_sondes_first_circle_Feb05.ta.T.plot(ax=ax0, cmap="magma")
-ds_sondes_first_circle_Feb05.rh.T.plot(ax=ax1, cmap="BrBG")
+ds_sondes_first_circle_Feb05.ta.transpose("alt", "sounding").plot(ax=ax0, cmap="magma")
+ds_sondes_first_circle_Feb05.rh.transpose("alt", "sounding").plot(ax=ax1, cmap="BrBG")
 None
 ```
 
@@ -129,21 +129,21 @@ fig, (ax0, ax1) = plt.subplots(1, 2)
 
 y = ds_sondes_first_circle_Feb05.alt
 
-x0 = ds_sondes_first_circle_Feb05.ta
+x0 = ds_sondes_first_circle_Feb05.ta.transpose("alt", "sounding")
 ax0.set_prop_cycle(color=plt.cm.viridis(np.linspace(0, 1, len(dropsonde_ids))))
-ax0.plot(x0.T, y.data[:, np.newaxis])
+ax0.plot(x0, y.data[:, np.newaxis])
 ax0.set_xlabel(f"{x0.long_name} / {x0.units}")
 ax0.set_ylabel(f"{y.name} / m")
 ax0.legend([dt64_to_dt(d).strftime("%H:%M:%S")
             for d in ds_sondes_first_circle_Feb05.launch_time],
            title=x0.launch_time.name)
 
-x1 = ds_sondes_first_circle_Feb05.rh
+x1 = ds_sondes_first_circle_Feb05.rh.transpose("alt", "sounding")
 c = ds_sondes_first_circle_Feb05.PW
 
 ax1.set_prop_cycle(color=plt.cm.BrBG([int(i) for i in (c - c.min())#cividis_r
                                            / (c - c.min()).max() * 255]))
-p = ax1.plot(x1.T, y.data[:, np.newaxis])
+p = ax1.plot(x1, y.data[:, np.newaxis])
 ax1.set_xlabel(f"{x1.long_name} / {x1.units}")
 ax1.set_ylabel(f"{y.name} / m")
 ax1.legend(ds_sondes_first_circle_Feb05.PW.values,
@@ -163,7 +163,7 @@ ds_sondes_Feb05 = ds.isel(sounding=mask_sondes_Feb05)
 ```{code-cell} ipython3
 with plt.style.context("mplstyle/wide"):
     fig, ax = plt.subplots()
-    p = ax.pcolormesh(ds_sondes_Feb05.wspd.T, vmin=0, vmax=20)#var.T
+    p = ax.pcolormesh(ds_sondes_Feb05.wspd.transpose("alt", "sounding"), vmin=0, vmax=20)
     plt.colorbar(p, ax=ax, label=f"{ds_sondes_Feb05.wspd.long_name} / {ds_sondes_Feb05.wspd.units}")
     xticks = np.arange(0, ds_sondes_Feb05.sounding.size, int(ds_sondes_Feb05.sounding.size/10))
     ax.set_xticks(xticks)

--- a/how_to_eurec4a/dropsondes.md
+++ b/how_to_eurec4a/dropsondes.md
@@ -111,7 +111,7 @@ import matplotlib.pyplot as plt
 plt.style.use("./mplstyle/book")
 ```
 
-* Figure 1: Temperature and relative humidity as stored in the xarray dataset
+### Temperature and relative humidity as stored in the xarray dataset
 
 ```{code-cell} ipython3
 fig, (ax0, ax1) = plt.subplots(1, 2)
@@ -119,7 +119,7 @@ ds_sondes_first_circle_Feb05.ta.T.plot(ax=ax0, cmap="magma")
 ds_sondes_first_circle_Feb05.rh.T.plot(ax=ax1, cmap="BrBG")
 ```
 
-* Figure 2: Temperature and relative humidity profiles.  
+### Temperature and relative humidity profiles.
 The temperature profiles are colored according to their launch time, while relative humidity profiles are colored according to their integrated water vapour in the measured column, i.e. precipitable water.
 
 ```{code-cell} ipython3
@@ -155,7 +155,7 @@ ax1.legend(ds_sondes_first_circle_Feb05.PW.values,
 fig.suptitle('Dropsondes from 1st circle an February 5', fontsize=18)
 ```
 
-* Figure 3: wind speed variations throughout February 5
+### wind speed variations throughout February 5
 
 ```{code-cell} ipython3
 mask_sondes_Feb05 = [dt64_to_dt(t).date() == datetime.date(2020,2,5)

--- a/how_to_eurec4a/dropsondes.md
+++ b/how_to_eurec4a/dropsondes.md
@@ -19,19 +19,13 @@ during EUREC4A - ATOMIC.
 More information on the dataset can be found at https://github.com/Geet-George/JOANNE/tree/master/joanne/Level_3#level---3.
 If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` and `author`.
 
-```{code-cell} ipython3
-import logging
-from functools import reduce
-
-import eurec4a
-```
-
 ## Get data
 * To load the data we first load the EUREC4A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
 
 ```{code-cell} ipython3
 import datetime
 import numpy as np
+import eurec4a
 cat = eurec4a.get_intake_catalog()
 list(cat)
 ```
@@ -93,6 +87,7 @@ dropsonde_ids
 We transfer the information from our flight segment selection to the dropsondes data in the xarray dataset.
 
 ```{code-cell} ipython3
+from functools import reduce
 mask_sondes_first_circle_Feb05 = reduce(lambda a, b: a | b, [ds.sonde_id==d
                                                              for d in dropsonde_ids])
 ds_sondes_first_circle_Feb05 = ds.isel(sounding=mask_sondes_first_circle_Feb05)

--- a/how_to_eurec4a/dropsondes.md
+++ b/how_to_eurec4a/dropsondes.md
@@ -20,10 +20,6 @@ More information on the dataset can be found at https://github.com/Geet-George/J
 If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` and `author`.
 
 ```{code-cell} ipython3
-%pylab inline
-```
-
-```{code-cell} ipython3
 import logging
 from functools import reduce
 
@@ -34,6 +30,8 @@ import eurec4a
 * To load the data we first load the EUREC4A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
 
 ```{code-cell} ipython3
+import datetime
+import numpy as np
 cat = eurec4a.get_intake_catalog()
 list(cat)
 ```
@@ -108,15 +106,15 @@ fetching the data and displaying it might take a few seconds
 ```
 
 ```{code-cell} ipython3
-import matplotlib as mpl
+%matplotlib inline
 import matplotlib.pyplot as plt
-mpl.rcParams['font.size'] = 14
+plt.style.use("./mplstyle/book")
 ```
 
 * Figure 1: Temperature and relative humidity as stored in the xarray dataset
 
 ```{code-cell} ipython3
-fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(12,7))
+fig, (ax0, ax1) = plt.subplots(1, 2)
 ds_sondes_first_circle_Feb05.ta.T.plot(ax=ax0, cmap="magma")
 ds_sondes_first_circle_Feb05.rh.T.plot(ax=ax1, cmap="BrBG")
 ```
@@ -131,7 +129,8 @@ def dt64_to_dt(dt64):
 ```
 
 ```{code-cell} ipython3
-fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(12,7))
+fig, (ax0, ax1) = plt.subplots(1, 2)
+
 y = ds_sondes_first_circle_Feb05.alt
 x0 = ds_sondes_first_circle_Feb05.ta
 ax0.set_prop_cycle(color=plt.get_cmap("viridis")(np.linspace(0, 1, len(dropsonde_ids))))
@@ -145,16 +144,14 @@ ax0.legend([dt64_to_dt(d).strftime("%H:%M:%S")
 x1 = ds_sondes_first_circle_Feb05.rh
 c = ds_sondes_first_circle_Feb05.PW
 
-ax1.set_prop_cycle(color=mpl.cm.BrBG([int(i) for i in (c - c.min())#cividis_r
+ax1.set_prop_cycle(color=plt.cm.BrBG([int(i) for i in (c - c.min())#cividis_r
                                            / (c - c.min()).max() * 255]))
 p = ax1.plot(x1.T, y.data[:, np.newaxis])
 ax1.set_xlabel(f"{x1.long_name} / {x1.units}")
 ax1.set_ylabel(f"{y.name} / m")
 ax1.legend(ds_sondes_first_circle_Feb05.PW.values,
            title=ds_sondes_first_circle_Feb05.PW.standard_name)
-for ax in [ax0, ax1]:
-    ax.spines['right'].set_visible(False)
-    ax.spines['top'].set_visible(False)
+
 fig.suptitle('Dropsondes from 1st circle an February 5', fontsize=18)
 ```
 
@@ -167,15 +164,16 @@ ds_sondes_Feb05 = ds.isel(sounding=mask_sondes_Feb05)
 ```
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots(figsize=(12,4))
-p = ax.pcolormesh(ds_sondes_Feb05.wspd.T, vmin=0, vmax=20)#var.T
-plt.colorbar(p, ax=ax, label=f"{ds_sondes_Feb05.wspd.long_name} / {ds_sondes_Feb05.wspd.units}")
-xticks = np.arange(0, ds_sondes_Feb05.sounding.size, int(ds_sondes_Feb05.sounding.size/10))
-ax.set_xticks(xticks)
-ax.set_xticklabels([dt64_to_dt(t).strftime("%H:%M") for t in ds.launch_time.values[xticks]])
-ax.set_xlabel(f"{ds_sondes_Feb05.launch_time.long_name}")
-yticks = np.arange(0, ds_sondes_Feb05.alt.size, int(ds_sondes_Feb05.alt.size/5))
-ax.set_yticks(yticks)
-ax.set_yticklabels(ds_sondes_Feb05.alt.values[yticks])
-ax.set_ylabel(f"{ds_sondes_Feb05.alt.name} / m")
+with plt.style.context("mplstyle/wide"):
+    fig, ax = plt.subplots()
+    p = ax.pcolormesh(ds_sondes_Feb05.wspd.T, vmin=0, vmax=20)#var.T
+    plt.colorbar(p, ax=ax, label=f"{ds_sondes_Feb05.wspd.long_name} / {ds_sondes_Feb05.wspd.units}")
+    xticks = np.arange(0, ds_sondes_Feb05.sounding.size, int(ds_sondes_Feb05.sounding.size/10))
+    ax.set_xticks(xticks)
+    ax.set_xticklabels([dt64_to_dt(t).strftime("%H:%M") for t in ds.launch_time.values[xticks]])
+    ax.set_xlabel(f"{ds_sondes_Feb05.launch_time.long_name}")
+    yticks = np.arange(0, ds_sondes_Feb05.alt.size, int(ds_sondes_Feb05.alt.size/5))
+    ax.set_yticks(yticks)
+    ax.set_yticklabels(ds_sondes_Feb05.alt.values[yticks])
+    ax.set_ylabel(f"{ds_sondes_Feb05.alt.name} / m")
 ```

--- a/how_to_eurec4a/dropsondes.md
+++ b/how_to_eurec4a/dropsondes.md
@@ -27,7 +27,6 @@ import datetime
 import numpy as np
 import eurec4a
 cat = eurec4a.get_intake_catalog()
-list(cat)
 ```
 
 * We can funrther specify the platform, instrument, if applicable dataset level or variable name, and pass it on to dask.

--- a/how_to_eurec4a/flight_tracks_leaflet.md
+++ b/how_to_eurec4a/flight_tracks_leaflet.md
@@ -20,7 +20,6 @@ This notebook shows how to plot the flight tracks of the HALO aircraft. First, w
 First, we'll import pylab and the EUREC4A data catalog.
 
 ```{code-cell} ipython3
-%pylab inline
 import eurec4a
 cat = eurec4a.get_intake_catalog()
 ```
@@ -58,6 +57,11 @@ dsfixed
 Just to have a better visual impression, we can create a quick overview plot of the data:
 
 ```{code-cell} ipython3
+%matplotlib inline
+import numpy as np
+import matplotlib.pyplot as plt
+plt.style.use("./mplstyle/book")
+
 plt.plot(dsfixed.lon, dsfixed.lat)
 plt.show()
 ```
@@ -89,7 +93,7 @@ dssimplified
 We can now compare those two tracks side by side while keeping a look at the number of data points required.
 
 ```{code-cell} ipython3
-fig, (ax1, ax2) = subplots(1, 2, figsize=(15,4))
+fig, (ax1, ax2) = plt.subplots(1, 2)
 ax1.plot(dsfixed.lon, dsfixed.lat)
 ax1.set_title(f"{len(dsfixed.time)} data points")
 ax2.plot(dssimplified.lon, dssimplified.lat)
@@ -156,6 +160,7 @@ tracks = {flight_id: simplify_dataset(ds, 1e-5)
 Let's also quickly grab some colors from a matplotlib colorbar, such that we can show all tracks in individual colors:
 
 ```{code-cell} ipython3
+import matplotlib
 colors = [matplotlib.colors.to_hex(c)
           for c in plt.cm.inferno(np.linspace(0, 1, len(tracks)))]
 ```

--- a/how_to_eurec4a/flight_tracks_leaflet.md
+++ b/how_to_eurec4a/flight_tracks_leaflet.md
@@ -137,7 +137,7 @@ def get_dataset(flight_id):
     ds = cat.HALO.BAHAMAS.PositionAttitude[flight_id].to_dask()
     return flight_id, ds.load()
 
-full_tracks = dict(pool.map(get_dataset, cat.HALO.BAHAMAS.QL))
+full_tracks = dict(pool.map(get_dataset, cat.HALO.BAHAMAS.PositionAttitude))
 ```
 
 We still have to simplify the dataset, which is done here:

--- a/how_to_eurec4a/flight_tracks_leaflet.md
+++ b/how_to_eurec4a/flight_tracks_leaflet.md
@@ -40,6 +40,10 @@ import matplotlib.pyplot as plt
 plt.style.use("./mplstyle/book")
 
 plt.plot(ds.lon, ds.lat)
+center_lat = float(ds.lat.mean())
+plt.gca().set_aspect(1./np.cos(np.deg2rad(center_lat)))
+plt.xlabel("longitude / °")
+plt.ylabel("latitude / °")
 plt.show()
 ```
 
@@ -75,6 +79,14 @@ ax1.plot(ds.lon, ds.lat)
 ax1.set_title(f"{len(ds.time)} data points")
 ax2.plot(dssimplified.lon, dssimplified.lat)
 ax2.set_title(f"{len(dssimplified.time)} data points")
+
+for ax in (ax1, ax2):
+    ax.set_aspect(1./np.cos(np.deg2rad(center_lat)))
+    ax.set_xlabel("longitude / °")
+    ax.set_ylabel("latitude / °")
+    ax.label_outer()
+
+
 plt.show()
 
 ratio = len(dssimplified.time) / len(ds.time)

--- a/how_to_eurec4a/hamp_comparison.md
+++ b/how_to_eurec4a/hamp_comparison.md
@@ -13,6 +13,7 @@ kernelspec:
 
 # HAMP comparison
 This notebook shows a comparison of cloud features as detected by different parts of the Halo Microwave Package (HAMP) and includes data from WALES and specMACS for additional context.
+Another application of the HAMP data is included in the chapter {doc}`unified`.
 
 ```{code-cell} ipython3
 import numpy as np

--- a/how_to_eurec4a/hamp_comparison.md
+++ b/how_to_eurec4a/hamp_comparison.md
@@ -12,7 +12,7 @@ kernelspec:
 ---
 
 # HAMP comparison
-
+This notebook shows a comparison of cloud features as detected by different parts of the Halo Microwave Package (HAMP) and includes data from WALES and specMACS for additional context.
 
 ```{code-cell} ipython3
 import numpy as np

--- a/how_to_eurec4a/hamp_comparison.md
+++ b/how_to_eurec4a/hamp_comparison.md
@@ -22,10 +22,6 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes, mark_inset
 import glob
 
 import eurec4a
-
-%pylab inline
-
-
 cat = eurec4a.get_intake_catalog()
 ```
 
@@ -179,10 +175,13 @@ radar_y = radar_y - wgs_correction
 
 ## Plot timeseries
 ```{code-cell} ipython3
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.style.use("./mplstyle/book")
+
 fig, (ax3, ax2, ax1, ax,) = plt.subplots(
-    nrows=4, figsize=(10, 8), sharex=True,
+    nrows=4, sharex=True,
     gridspec_kw=dict(height_ratios=[1, 1, .75, 0.5]),
-    constrained_layout=True
 )
 
 ax.plot(wales.time, wales.cloud_mask + 0.2, '.', label='WALES', markersize=3)

--- a/how_to_eurec4a/hamp_comparison.md
+++ b/how_to_eurec4a/hamp_comparison.md
@@ -15,12 +15,7 @@ kernelspec:
 
 
 ```{code-cell} ipython3
-import xarray
 import numpy as np
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes, mark_inset
-import glob
-
 import eurec4a
 cat = eurec4a.get_intake_catalog()
 ```

--- a/how_to_eurec4a/meteor_cloudradar.md
+++ b/how_to_eurec4a/meteor_cloudradar.md
@@ -59,5 +59,5 @@ import matplotlib.pyplot as plt
 plt.style.use("./mplstyle/book")
 
 ds.Zh.plot(x='time', cmap="Spectral_r")  # plot the variable with time as the x axis
-plt.ylim(0, 3000)
+plt.ylim(0, 3000);
 ```

--- a/how_to_eurec4a/meteor_cloudradar.md
+++ b/how_to_eurec4a/meteor_cloudradar.md
@@ -56,6 +56,8 @@ An example which forces the data to load is plotting, in this case only the rada
 ```{code-cell} ipython3
 %matplotlib inline
 import matplotlib.pyplot as plt
+plt.style.use("./mplstyle/book")
+
 ds.Zh.plot(x='time', cmap="Spectral_r")  # plot the variable with time as the x axis
 plt.ylim(0, 3000)
 ```

--- a/how_to_eurec4a/mplstyle/book
+++ b/how_to_eurec4a/mplstyle/book
@@ -1,0 +1,7 @@
+figure.constrained_layout.use: True
+figure.figsize: 10, 6
+figure.dpi: 200
+font.size: 10
+
+axes.spines.top: False
+axes.spines.right: False

--- a/how_to_eurec4a/mplstyle/wide
+++ b/how_to_eurec4a/mplstyle/wide
@@ -1,0 +1,1 @@
+figure.figsize: 10, 4

--- a/how_to_eurec4a/references.bib
+++ b/how_to_eurec4a/references.bib
@@ -65,3 +65,11 @@ year = {2021},
 pages = {1--25},
 DOI = {10.5194/essd-2021-11}
 }
+
+
+@Article{Konow:2021,
+    author = {Konow, Heike},
+    title = {EUREC4A's {HALO}},
+    journal = {tbd},
+    year = {2021}
+}

--- a/how_to_eurec4a/smart.md
+++ b/how_to_eurec4a/smart.md
@@ -35,7 +35,9 @@ list(cat.HALO.SMART)
 
 * We can further specify the platform, instrument, if applicable dataset level or variable name, and pass it on to dask.
 
-*Note: have a look at the attributes of the xarray dataset `ds` for all relevant information on the dataset, such as author, contact, or citation infromation.*
+```{note}
+Have a look at the attributes of the xarray dataset `ds_smart` for all relevant information on the dataset, such as author, contact, or citation infromation.
+```
 
 ```{code-cell} ipython3
 ds_smart = cat.HALO.SMART.spectral_irradiances['HALO-0205'].to_dask()

--- a/how_to_eurec4a/smart.md
+++ b/how_to_eurec4a/smart.md
@@ -29,7 +29,7 @@ cat = eurec4a.get_intake_catalog()
 list(cat.HALO.SMART)
 ```
 
-* We can further specify the platform, instrument, if applicable dataset level or variable name, and pass it on to dask.
+* We can further specify a product and a flight and obtain the dataset using `to_dask`.
 
 ```{note}
 Have a look at the attributes of the xarray dataset `ds_smart` for all relevant information on the dataset, such as author, contact, or citation infromation.

--- a/how_to_eurec4a/smart.md
+++ b/how_to_eurec4a/smart.md
@@ -17,10 +17,6 @@ The following script exemplifies the access and usage of SMART data measured dur
 
 More information on the dataset can be found in [Stevens et al. (2019)](https://doi.org/10.1175/BAMS-D-18-0198.1) and [Wendisch et al. (2001)](https://doi.org/10.1175/1520-0426(2001)018%3C1856:AASAWA%3E2.0.CO;2). If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
-```{code-cell} ipython3
-%pylab inline
-```
-
 ## Get data
 * To load the data we first load the EUREC4A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
 
@@ -49,6 +45,10 @@ The available dataset includes irradiances for six selected wavelengths (422nm, 
 First Quickplot of whole flight (one wavelength)
 
 ```{code-cell} ipython3
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.style.use("./mplstyle/book")
+
 ds_smart.F_down_solar_wl_422.plot()
 ```
 
@@ -83,14 +83,10 @@ ds_smart_selection = ds_smart.sel(time=slice(seg["start"], seg["end"]))
 We plot the spectral irradiances from different wavelengths measured with SMART during the selected flight segment.
 
 ```{code-cell} ipython3
-mpl.rcParams['font.size'] = 12
-
 fig, ax = plt.subplots()
 wl_list=[422,532,648,858,1238,1638]
 for i in wl_list:
     ds_smart_selection[f'F_down_solar_wl_{i}'].plot(label =f'{i} nm')
 ax.legend()
 ax.set_ylabel('Spectral downward irradiance / Wm$^{-2}$nm$^{-1}$')
-ax.spines['right'].set_visible(False)
-ax.spines['top'].set_visible(False)
 ```

--- a/how_to_eurec4a/smart.md
+++ b/how_to_eurec4a/smart.md
@@ -49,7 +49,7 @@ First Quickplot of whole flight (one wavelength)
 import matplotlib.pyplot as plt
 plt.style.use("./mplstyle/book")
 
-ds_smart.F_down_solar_wl_422.plot()
+ds_smart.F_down_solar_wl_422.plot();
 ```
 
 ## Load HALO flight phase information
@@ -89,4 +89,5 @@ for i in wl_list:
     ds_smart_selection[f'F_down_solar_wl_{i}'].plot(label =f'{i} nm')
 ax.legend()
 ax.set_ylabel('Spectral downward irradiance / Wm$^{-2}$nm$^{-1}$')
+None
 ```

--- a/how_to_eurec4a/specmacs.md
+++ b/how_to_eurec4a/specmacs.md
@@ -456,6 +456,8 @@ cmplot = ds_selection.cloud_mask.plot(ax=ax,
                                       cmap=plt.get_cmap('Greys_r', lut=3),
                                       vmin=-0.5, vmax=2.5,
                                       add_colorbar=False)
+# approximate aspect ratio of latitude and longitude length scales
+ax.set_aspect(1./np.cos(np.deg2rad(float(ds_selection.cloudlat.mean()))))
 flagbar(fig, cmplot, ds_selection.cloud_mask);
 ```
 

--- a/how_to_eurec4a/specmacs.md
+++ b/how_to_eurec4a/specmacs.md
@@ -73,7 +73,7 @@ cat = eurec4a.get_intake_catalog()
 ```
 
 ```{code-cell} ipython3
-dropsondes = cat.dropsondes.JOANNE.level3.to_dask().load()
+dropsondes = cat.dropsondes.JOANNE.level3.to_dask()
 # this following line should go away in the soon to be released new version of JOANNE
 sonde_dt = dropsondes.swap_dims({"sounding": "sonde_id"}).sel(sonde_id=first_dropsonde).launch_time.values
 str(sonde_dt)

--- a/how_to_eurec4a/specmacs.md
+++ b/how_to_eurec4a/specmacs.md
@@ -98,6 +98,7 @@ After selecting our datasets, we want to see what's inside, so here are some fir
 ```{code-cell} ipython3
 %matplotlib inline
 import matplotlib.pyplot as plt
+plt.style.use(["./mplstyle/book", "./mplstyle/wide"])
 ```
 
 First, we create a little helper to properly display a colorbar for categorical (in CF-Convention terms "flag") variables:
@@ -117,7 +118,7 @@ fetching the data and displaying it might take a few seconds
 ```
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots(figsize=(16,4))
+fig, ax = plt.subplots()
 cmplot = ds_selection.cloud_mask.T.plot(ax=ax,
                                         cmap=plt.get_cmap('Greys_r', lut=3),
                                         vmin=-0.5, vmax=2.5,
@@ -130,14 +131,12 @@ ax.set_title(f"specMACS cloud mask ({start_time_rounded} - {end_time_rounded})")
 The dataset also contains the minimal and maximal cloud fractions which are calculated for each temporal measurement. The minimal cloud fraction is derived from the ratio between the number of pixels classified as "most likely cloudy" and the total number of pixels in one measurement (times with unknown measurements are excluded). The maximal cloud fraction additionally includes the number of pixels classified as "probably cloudy".
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots(figsize=(10, 4))
+fig, ax = plt.subplots()
 ds_selection.CF_max.plot(color="lightgrey",label="maximal cloud_fraction:\nmost likely cloudy and probably cloudy")
 ds_selection.CF_min.plot(color="grey", label="minimal cloud fraction:\nmost_likely_cloudy")
 ax.axvline(sonde_dt, color="C3", label="sonde launch time")
 ax.set_ylim(0, 1)
 ax.set_ylabel("Cloud fraction")
-ax.spines['right'].set_visible(False)
-ax.spines['top'].set_visible(False)
 ax.set_title(f"cloud fraction around sonde {first_dropsonde}")
 ax.legend(bbox_to_anchor=(1,1), loc="upper left");
 ```
@@ -451,7 +450,7 @@ ds_selection
 `ds.cloudlon` and `ds.cloudlat` are the projected longitude and latitude coordinates of the cloud. Now it is possible to plot the cloudmask on a map!
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots(figsize=(14,6))
+fig, ax = plt.subplots()
 cmplot = ds_selection.cloud_mask.plot(ax=ax,
                                       x='cloudlon', y='cloudlat',
                                       cmap=plt.get_cmap('Greys_r', lut=3),

--- a/how_to_eurec4a/unified.md
+++ b/how_to_eurec4a/unified.md
@@ -29,7 +29,7 @@ cat = eurec4a.get_intake_catalog()
 list(cat.HALO.UNIFIED)
 ```
 
-* We can funrther specify the platform, instrument, if applicable dataset level or variable name, and pass it on to dask.
+* We can further specify the platform, instrument, if applicable dataset level or variable name, and pass it on to dask.
 
 ```{note}
 Have a look at the attributes of the xarray dataset `ds` for all relevant information on the dataset, such as author, contact, or citation infromation.

--- a/how_to_eurec4a/unified.md
+++ b/how_to_eurec4a/unified.md
@@ -15,7 +15,7 @@ kernelspec:
 
 The HALO UNIFEID dataset is a combination of [HAMP](https://amt.copernicus.org/articles/7/4539/2014/) radar and radiometer measurements, [BAHAMAS](http://www.halo.dlr.de/instrumentation/basis.html) aircraft position data and [dropsonde](https://github.com/Geet-George/JOANNE#joanne---the-eurec4a-dropsonde-dataset) measurements, all on a unified temporal and spatial grid. 
 
-More information on the dataset can be found at `?`. If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
+More information on the dataset can be found at {cite}`Konow:2021`. If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
 ## Get data
 * To load the data we first load the EUREC4A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).

--- a/how_to_eurec4a/unified.md
+++ b/how_to_eurec4a/unified.md
@@ -99,4 +99,5 @@ ax2.set_title('')
 ax2.legend(bbox_to_anchor=(1,1.1))
 
 ax1.set_xlabel('')
+None
 ```

--- a/how_to_eurec4a/unified.md
+++ b/how_to_eurec4a/unified.md
@@ -35,7 +35,9 @@ list(cat.HALO.UNIFIED)
 
 * We can funrther specify the platform, instrument, if applicable dataset level or variable name, and pass it on to dask.
 
-*Note: have a look at the attributes of the xarray dataset `ds` for all relevant information on the dataset, such as author, contact, or citation infromation.*
+```{note}
+Have a look at the attributes of the xarray dataset `ds` for all relevant information on the dataset, such as author, contact, or citation infromation.
+```
 
 ```{code-cell} ipython3
 ds_radar = cat.HALO.UNIFIED.HAMPradar["HALO-0205"].to_dask()

--- a/how_to_eurec4a/unified.md
+++ b/how_to_eurec4a/unified.md
@@ -79,12 +79,13 @@ import numpy as np
 import matplotlib.pyplot as plt
 plt.style.use("./mplstyle/book")
 
-fig, (ax1, ax2) = plt.subplots(2,1,sharex=True, gridspec_kw={'height_ratios':(2, 1.2)})
+fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True, gridspec_kw={'height_ratios':(2, 1.2)})
 
 # 1st plot: Radar dBZ and flight altitude
-ds_bahamas_selection.altitude.plot(ax=ax1, x='time', color = 'black', label = 'flight altitude')
+ds_bahamas_selection.altitude.plot(ax=ax1, x='time', color='black', label='flight altitude')
+ax1.set_xlabel('')
 ax1.legend(loc ='upper left')
-ds_radar_selection.dBZ.plot(ax= ax1, x='time', cmap ='cubehelix' )
+ds_radar_selection.dBZ.plot(ax=ax1, x='time', cmap='cubehelix' )
 
 # 2nd plot: Radiometer TB
 ## select low frequency channels along the 22 GHz water vapor line
@@ -97,7 +98,5 @@ for frequency, data_radiometer in ds_radiometer_low_freq.groupby("frequency"):
     data_radiometer.tb.plot(ax=ax2, x='time', label=f'{frequency:.2f} GHz')
 ax2.set_title('')
 ax2.legend(bbox_to_anchor=(1,1.1))
-
-ax1.set_xlabel('')
 None
 ```

--- a/how_to_eurec4a/unified.md
+++ b/how_to_eurec4a/unified.md
@@ -83,9 +83,9 @@ fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True, gridspec_kw={'height_ratios':(
 
 # 1st plot: Radar dBZ and flight altitude
 ds_bahamas_selection.altitude.plot(ax=ax1, x='time', color='black', label='flight altitude')
-ax1.set_xlabel('')
 ax1.legend(loc ='upper left')
 ds_radar_selection.dBZ.plot(ax=ax1, x='time', cmap='cubehelix' )
+ax1.set_xlabel('')
 
 # 2nd plot: Radiometer TB
 ## select low frequency channels along the 22 GHz water vapor line

--- a/how_to_eurec4a/unified.md
+++ b/how_to_eurec4a/unified.md
@@ -29,7 +29,7 @@ cat = eurec4a.get_intake_catalog()
 list(cat.HALO.UNIFIED)
 ```
 
-* We can further specify the platform, instrument, if applicable dataset level or variable name, and pass it on to dask.
+* We can further specify an instrument and a flight and obtain the dataset using `to_dask`.
 
 ```{note}
 Have a look at the attributes of the xarray dataset `ds` for all relevant information on the dataset, such as author, contact, or citation infromation.

--- a/how_to_eurec4a/unified.md
+++ b/how_to_eurec4a/unified.md
@@ -17,10 +17,6 @@ The HALO UNIFEID dataset is a combination of [HAMP](https://amt.copernicus.org/a
 
 More information on the dataset can be found at `?`. If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
-```{code-cell} ipython3
-%pylab inline
-```
-
 ## Get data
 * To load the data we first load the EUREC4A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
 
@@ -78,9 +74,12 @@ ds_bahamas_selection = ds_bahamas.sel(time=slice(seg["start"], seg["end"]))
 We plot reflectivity from the HAMP Radar, the flight altitude of HALO and brightness temperatures from the low-frequency channels along the 22 GHz water vapor line (K band) from the HAMP radiometer.
 
 ```{code-cell} ipython3
-mpl.rcParams['font.size'] = 12
+%matplotlib inline
+import numpy as np
+import matplotlib.pyplot as plt
+plt.style.use("./mplstyle/book")
 
-fig, (ax1, ax2) = plt.subplots(2,1,sharex=True, figsize=(10,5), constrained_layout=True, gridspec_kw={'height_ratios':(2, 1.2)})
+fig, (ax1, ax2) = plt.subplots(2,1,sharex=True, gridspec_kw={'height_ratios':(2, 1.2)})
 
 # 1st plot: Radar dBZ and flight altitude
 ds_bahamas_selection.altitude.plot(ax=ax1, x='time', color = 'black', label = 'flight altitude')
@@ -100,7 +99,4 @@ ax2.set_title('')
 ax2.legend(bbox_to_anchor=(1,1.1))
 
 ax1.set_xlabel('')
-for ax in [ax1, ax2]:
-    ax.spines['right'].set_visible(False)
-    ax.spines['top'].set_visible(False)
 ```

--- a/how_to_eurec4a/velox.md
+++ b/how_to_eurec4a/velox.md
@@ -32,18 +32,10 @@ No data available for the transfer flights (first and last) and the first local 
 ```
 
 ```{code-cell} ipython3
-%pylab inline
-```
-
-```{code-cell} ipython3
 import eurec4a
 import intake
 import xarray as xr
-
-import matplotlib as mpl
-mpl.rcParams['font.size'] = 12
 ```
-
 ## Get data
 To load the data we first load the [EUREC4A intake catalog](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue) and list the available datasets from VELOX.  
 Currently, there is a cloud mask product available.
@@ -83,6 +75,8 @@ segments = [{**s,
 (1) we extract the segment ID of the second `circle`
 
 ```{code-cell} ipython3
+import datetime
+
 segments_ordered_by_start_time = list(sorted(segments, key=lambda s: s["start"]))
 circles_Feb05 = [s["segment_id"]
                  for s in segments_ordered_by_start_time
@@ -124,6 +118,10 @@ ds_sel = ds.cloud_mask.sel(time=sonde_dt, method="nearest")
 ```
 
 ```{code-cell} ipython3
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.style.use("./mplstyle/book")
+
 fig, ax = plt.subplots()
 
 cax = ds_sel.plot(ax=ax,
@@ -161,16 +159,15 @@ seg = {s["segment_id"]: {**s, "flight_id": flight["flight_id"]}
 The dataset variable `CF_min` provides a lower bound to cloud fraction estimates based on the cloud mask flag `most_likely_cloudy`, while `CF_max` provides an upper bound by including the uncertain pixels labeled `probably cloudy`.
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots(figsize=(10, 4))
-ds.CF_min.sel(time=slice(seg["start"], seg["end"])).plot(color="k",
-                                                         label="most_likely_cloudy")
-ds.CF_max.sel(time=slice(seg["start"], seg["end"])).plot(color="grey",
-                                                         label="most_likely_cloudy\nand probably_cloudy")
-ax.axvline(sonde_dt, color="C3", label="sonde launch time")
-ax.set_ylim(0, 1)
-ax.set_ylabel("Cloud fraction")
-ax.spines['right'].set_visible(False)
-ax.spines['top'].set_visible(False)
-ax.set_title("Second circle on February 5")
-ax.legend(title="Cloud mask flags", bbox_to_anchor=(1,1), loc="upper left")
+selection = ds.sel(time=slice(seg["start"], seg["end"]))
+
+with plt.style.context("mplstyle/wide"):
+    fig, ax = plt.subplots()
+    selection.CF_min.plot(color="k", label="most_likely_cloudy")
+    selection.CF_max.plot(color="grey", label="most_likely_cloudy\nand probably_cloudy")
+    ax.axvline(sonde_dt, color="C3", label="sonde launch time")
+    ax.set_ylim(0, 1)
+    ax.set_ylabel("Cloud fraction")
+    ax.set_title("Second circle on February 5")
+    ax.legend(title="Cloud mask flags", bbox_to_anchor=(1,1), loc="upper left");
 ```

--- a/how_to_eurec4a/velox.md
+++ b/how_to_eurec4a/velox.md
@@ -96,7 +96,7 @@ So far, we only made use of the flight segmentation meta data. The launch time t
 We use again the intake catalog to load the JOANNE dataset and extract the launch time to the selected dropsonde by it's sonde ID.
 
 ```{code-cell} ipython3
-dropsondes = cat.dropsondes.JOANNE.level3.to_dask().load()
+dropsondes = cat.dropsondes.JOANNE.level3.to_dask()
 ```
 
 ```{code-cell} ipython3

--- a/how_to_eurec4a/velox.md
+++ b/how_to_eurec4a/velox.md
@@ -27,7 +27,9 @@ The PI during EUREC4A was Michael Schäfer (University Leipzig).
 
 If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
-*Note: no data available for the transfer flights (first and last) and the first local research flight.*
+```{note}
+No data available for the transfer flights (first and last) and the first local research flight.
+```
 
 ```{code-cell} ipython3
 %pylab inline

--- a/how_to_eurec4a/velox.md
+++ b/how_to_eurec4a/velox.md
@@ -144,11 +144,7 @@ print(f"Image maximum cloud fraction (most likely and probably cloudy) :{cfmax:.
 We also want to show a time series of cloud fraction and use the segment ID from the second circle to extract and save the segment information to the variable `seg`. We can later use the segments start and end times to select the data in time.
 
 ```{code-cell} ipython3
-seg = {s["segment_id"]: {**s, "flight_id": flight["flight_id"]}
-             for platform in meta.values()
-             for flight in platform.values()
-             for s in flight["segments"]
-            }[second_circle_Feb05]
+seg = segments_by_segment_id[second_circle_Feb05]
 ```
 
 The dataset variable `CF_min` provides a lower bound to cloud fraction estimates based on the cloud mask flag `most_likely_cloudy`, while `CF_max` provides an upper bound by including the uncertain pixels labeled `probably cloudy`.

--- a/how_to_eurec4a/velox.md
+++ b/how_to_eurec4a/velox.md
@@ -31,11 +31,6 @@ If you have questions or if you would like to use the data for a publication, pl
 No data available for the transfer flights (first and last) and the first local research flight.
 ```
 
-```{code-cell} ipython3
-import eurec4a
-import intake
-import xarray as xr
-```
 ## Get data
 To load the data we first load the [EUREC4A intake catalog](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue) and list the available datasets from VELOX.  
 Currently, there is a cloud mask product available.

--- a/how_to_eurec4a/wales.md
+++ b/how_to_eurec4a/wales.md
@@ -26,15 +26,8 @@ Due to safety regulations the Lidar can only be operated above 6 km which leads 
 ```
 
 ```{code-cell} ipython3
-%pylab inline
-```
-
-```{code-cell} ipython3
 import eurec4a
-
 import xarray as xr
-import matplotlib as mpl
-mpl.rcParams['font.size'] = 12
 ```
 
 ## Get data
@@ -69,8 +62,12 @@ cm_meanings
 
 
 ```{code-cell} ipython3
-fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True,
-                                    constrained_layout=True)
+%matplotlib inline
+import numpy as np
+import matplotlib.pyplot as plt
+plt.style.use("./mplstyle/book")
+
+fig, axes = plt.subplots(3, 1, sharex=True)
 ax1, ax2, ax3 = axes
 
 cloud_free = ds_cloud_sel.cloud_mask[ds_cloud_sel.cloud_mask == cm_meanings["cloud_free"]]
@@ -104,12 +101,10 @@ thick_cloud_top = ds_cloud_sel.cloud_top[ds_cloud_sel.cloud_ot>3]
 thick_cloud_top.plot(ax=ax3, x="time", ls="", marker=".", color="k", label="cloud top (OT > 3)")
 
 ax3.set_ylim(0, 2000)
-ax3.set_ylabel("height above sea level [m]")
+ax3.set_ylabel("height above sea [m]")
 ax3.set_xlabel('time in UTC')
 
 for ax in axes:
-    ax.spines['right'].set_visible(False)
-    ax.spines['top'].set_visible(False)
     ax.label_outer()
     ax.legend()
 
@@ -165,18 +160,17 @@ Indeed, this is different... Good that we have thought about it.
 We can now use a time averaging window to derive a time dependent cloud fraction from the `cloud_mask` variable and see how it varies over the course of the flight.
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots(figsize=(10, 4))
+with plt.style.context("mplstyle/wide"):
+    fig, ax = plt.subplots()
 
-ax.set_prop_cycle(color=plt.get_cmap("magma")(np.linspace(0, 1, 4)))
-for ind, t in enumerate([1, 5, 10]):
-    averaged_cloud_fraction = min_cloud_binary_mask.resample(time=f"{t}min", loffset=f"{t/2}min").mean()
-    averaged_cloud_fraction.plot(lw=ind + 1, label=f"{t} min")
+    ax.set_prop_cycle(color=plt.get_cmap("magma")(np.linspace(0, 1, 4)))
+    for ind, t in enumerate([1, 5, 10]):
+        averaged_cloud_fraction = min_cloud_binary_mask.resample(time=f"{t}min", loffset=f"{t/2}min").mean()
+        averaged_cloud_fraction.plot(lw=ind + 1, label=f"{t} min")
 
-ax.set_ylim(0, 1)
-ax.set_ylabel("Cloud fraction")
-ax.set_xlabel("date: MM-DD HH")
-ax.spines['right'].set_visible(False)
-ax.spines['top'].set_visible(False)
-ax.legend(title="averaging period", bbox_to_anchor=(1,1), loc="upper left")
-None
+    ax.set_ylim(0, 1)
+    ax.set_ylabel("Cloud fraction")
+    ax.set_xlabel("date: MM-DD HH")
+    ax.legend(title="averaging period", bbox_to_anchor=(1,1), loc="upper left")
+    None
 ```

--- a/how_to_eurec4a/wales.md
+++ b/how_to_eurec4a/wales.md
@@ -55,12 +55,13 @@ We explicitly `load()` the dataset at this stage as want to use this subset mult
 ```
 
 ```{code-cell} ipython3
-                                       datetime.datetime(2020, 2, 5, 13, 7, 30))).load()
+ds_cloud_sel = ds_cloud.sel(time=slice("2020-02-05T13:06:30", "2020-02-05T13:07:030")).load()
 ```
 
 In order to work with the different cloud mask flags, we extract the meanings into a dictionary, which we can later use to select relevant data:
 ```{code-cell} ipython3
-cm_meanings = dict(zip(ds_cloud_sel.cloud_mask.flag_meanings.split(" "), ds_cloud_sel.cloud_mask.flag_values))
+cm_meanings = dict(zip(ds_cloud_sel.cloud_mask.flag_meanings.split(" "),
+                       ds_cloud_sel.cloud_mask.flag_values))
 cm_meanings
 ```
 

--- a/how_to_eurec4a/wales.md
+++ b/how_to_eurec4a/wales.md
@@ -21,7 +21,9 @@ At typical flight speeds of 200 m/s the backscatter product from the HSRL has a 
 
 More information on the instrument can be found in [Wirth et al., 2009](https://elib.dlr.de/58175/). If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
-*Note: due to safety regulations the Lidar can only be operated above 6 km which leads to data gaps in about the first and last 30 minutes of each flight.*
+```{note}
+Due to safety regulations the Lidar can only be operated above 6 km which leads to data gaps in about the first and last 30 minutes of each flight.
+```
 
 ```{code-cell} ipython3
 %pylab inline

--- a/how_to_eurec4a/wales.md
+++ b/how_to_eurec4a/wales.md
@@ -43,15 +43,19 @@ print(cat.HALO.WALES.cloudparameter.description)
 ## Cloud parameter
 
 ```{code-cell} ipython3
-ds_cloud = cat.HALO.WALES.cloudparameter["HALO-0205"].to_dask().load()
+ds_cloud = cat.HALO.WALES.cloudparameter["HALO-0205"].to_dask()
 ds_cloud
 ```
 
 We select 1min of flight `time`. You can freely change the times or put `None` instead of the slice start and/or end to get up to the full flight data.
+We explicitly `load()` the dataset at this stage as want to use this subset multiple times in the following.
+
+```{note}
+`load()` should always be called late and in particular after subsetting the data to prevent loading more than necessary.
+```
 
 ```{code-cell} ipython3
-ds_cloud_sel = ds_cloud.sel(time=slice(datetime.datetime(2020, 2, 5, 13, 6, 30),
-                                       datetime.datetime(2020, 2, 5, 13, 7, 30)))
+                                       datetime.datetime(2020, 2, 5, 13, 7, 30))).load()
 ```
 
 In order to work with the different cloud mask flags, we extract the meanings into a dictionary, which we can later use to select relevant data:


### PR DESCRIPTION
This PR contains several individual commits which are intended to clean up the currently existing notebooks a bit. Some things which are included are:

* `%pylab inline` is deprecated and should not be used. It is quite likely that I introduced this silly piece of code, I think it is time to get rid of it :-)
* The above required some more changes to plotting code, I took this as a chance and created matplotlib stylesheets in `/how_to_eurec4a/mplstyle`. That way, plots should get a more common appearance. I'd suggest to update styles in these files as long as anyhow possible. Currently there are two files, the `book` which contains basic styles for all plots and `wide` which contains a wider figure aspect ratio which can occasionally be useful.
* included the new HALO `PositionAttitude` data instead of BAHAMAS `QL` data
* less unnecessary calls to `load()` to speed things up. (in general, one **doesn't** want to call this function)
* some more small code and formatting changes