### PR TITLE
Add multi-platform datasets starting with JOANNE dropsondes

### DIFF
--- a/how_to_eurec4a/_toc.yml
+++ b/how_to_eurec4a/_toc.yml
@@ -3,7 +3,6 @@
 - file: intro
 - file: halo
   sections:
-    - file: dropsondes
     - file: specmacs
     - file: unified
     - file: flight_tracks_leaflet
@@ -15,6 +14,9 @@
 - file: meteor
   sections:
     - file: meteor_cloudradar
+- file: multi_platform_data
+  sections:
+    - file: dropsondes
 - file: toolbox
   sections:
     - file: flight-phase-operations

--- a/how_to_eurec4a/multi_platform_data.md
+++ b/how_to_eurec4a/multi_platform_data.md
@@ -1,0 +1,3 @@
+# Multi-platform datasets
+
+Some datasets are synthesized from multiple platforms. 


### PR DESCRIPTION
JOANNE contains data measurements from multiple platforms but is currently listed under HALO. Why not have a category for "multi-platform datasets"? 