### PR TITLE
publish book on GitHub pages

### DIFF
--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -30,3 +30,19 @@ jobs:
         name: build
         path: |
           how_to_eurec4a/_build
+
+  publish:
+    needs: build
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/github_publish'"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download compiled book
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: _build
+      - name: Publish book on github pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/html

--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -33,7 +33,7 @@ jobs:
 
   publish:
     needs: build
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/github_publish'"
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/master'"
     runs-on: ubuntu-latest
     steps:
       - name: Download compiled book


### PR DESCRIPTION
This PR adds a workflow job to publish the book on github pages. We should later be able to add a custom domain. Until that is the case, I would **not** jet consider the copy on github pages to be the "official" one.

relevant issue: #53