### PR TITLE
Shorter timeout limit for notebooks, extended for one notebook

### DIFF
--- a/how_to_eurec4a/_config.yml
+++ b/how_to_eurec4a/_config.yml
@@ -23,6 +23,6 @@ html:
   use_edit_page_button      : true
 execute:
   execute_notebooks         : force
-  timeout: 300
+  timeout: 90
 bibtex_reference_style      : author_year
 bibtex_bibfiles             : references.bib

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -9,6 +9,8 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+execution:
+  timeout: 300
 ---
 
 # Cloud masks
@@ -274,7 +276,7 @@ axP.yaxis.set_visible(False)
 
 ## 1D
 # We plot 1D cloud masks
-# Each we annotate with a total min and max cloud fraction for the scene shown and 
+# Each we annotate with a total min and max cloud fraction for the scene shown and
 # remove disturbing spines
 lines = []
 plot_order = ['WALES', 'HAMP Radar', 'specMACS', 'HAMP Radiometer', 'KT19', 'VELOX']


### PR DESCRIPTION
Set the default time allowed for each notebook to 90 seconds but add metadata to the cloudmasks notebook to allow  300 seconds. 