### PR TITLE
Updates and corrections to the HALO cloudmask book chapter

### DIFF
--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -9,8 +9,6 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
-execution:
-  timeout: 300
 ---
 
 # Cloud masks
@@ -186,7 +184,7 @@ this dataset is only available for the following application on February 5, not 
 import ipfsspec
 
 ds_bt = xr.open_zarr("ipfs://QmQEwkhhHdJkiThf4hnj9G3wgqVreBnWGrX2A5kT6CrtY7",
-                     consolidated=True, storage_options={'normalize_keys': False}
+                     consolidated=True,
                     ).assign_coords(va=lambda x: x.va)
 ```
 

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -239,10 +239,6 @@ cloudmask_selectors = {
 
 ```{code-cell} ipython3
 data0205 = {k: ensure_cfminmax(v["HALO-0205"].to_dask()) for k, v in cat_cloudmask.items()}
-```
-
-```{code-cell} ipython3
-%%time
 data_feb5 = {k: cloudmask_selectors[k](v.sel(time=s)) for k, v in data0205.items()}
 ```
 

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -475,6 +475,15 @@ with plt.style.context("mplstyle/wide"):
     ax.set_xlabel("Date")
 ```
 
+### A small interpretation
+A few features stick out in the above figures showing the statistics:
+* the WALES dataset does not have a `probably_cloudy` flag, and thus, the `CF_min` and `CF_max` variables are the same. The instrument design and methodology used to define the cloud flag seems to be very sensitive to small and optically thin clouds and the cloud cover estimates agree better with the `CF_max` of all other instruments.
+* All instruments, excluding WALES, agree well in the distribution of circle-mean cloud cover estimates according to their `CF_min` variable, while they vary on their definition of uncertain `probably_cloudy` measurements that are included in `CF_max`.
+* On the transfer flight on 19 January the HAMP radar and radiometer and specMACS datasets were processed and datasets are available including one circle near Barbados. For WALES, VELOX, and KT19 no data is available.
+* The disagreement in cloud cover estimates for the flight on 15 February is partly due to a deep stratocumulus layer with a strong reflection at cloud top that blinded the lidar (WALES), while the radar was still able to provide reasonable estimates.
+
++++
+
 ## Camapign mean cloud cover
 * from all available data including the transfer flights
 

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -190,6 +190,12 @@ ds_bt = xr.open_zarr("ipfs://QmQEwkhhHdJkiThf4hnj9G3wgqVreBnWGrX2A5kT6CrtY7",
                     ).assign_coords(va=lambda x: x.va)
 ```
 
+#### Preprocess cloud mask data
+
+We copy the data dictionary and apply the time selection.
+
++++
+
 What is the angle of the 11 central pixel in accross track direction?
 
 ```{code-cell} ipython3
@@ -197,12 +203,6 @@ xmid = ds_bt.x.size // 2
 va_central = ds_bt.isel(time=0, x=slice(xmid - 5, xmid + 6)).va
 (va_central.max() - va_central.min()).values
 ```
-
-#### Preprocess cloud mask data
-
-We copy the data dictionary and apply the time selection.
-
-+++
 
 For the 2D horizontal imagers we select a region in the center, derive a representative (most frequent) `cloud_mask` flag value and use that in the following intercomparison plot.
 * VELOX: we select only the cetral 11 x 11 pixels, i.e. view angle = 0 ∓ 0.2865
@@ -495,5 +495,6 @@ localRF = slice("2020-01-22T00:00:00", "2020-02-15T23:59:59")
 print("Instrument: min - max")
 print("")
 for k, v in data.items():
-    print(f"{k}: {v.sel(time=rf).CF_min.mean().values:.2f} - {v.sel(time=rf).CF_max.mean().values:.2f} ")
+    print(f"{k}: {v.sel(time=localRF).CF_min.mean().values:.2f} - "
+          + f"{v.sel(time=localRF).CF_max.mean().values:.2f} ")
 ```

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -424,32 +424,41 @@ with plt.style.context("mplstyle/wide"):
     ax1.text(-0.1, ax.get_ylim()[1], "(b)", verticalalignment='top')
 ```
 
-### Time series of circle cloud fraction
-We display the daily mean of all circle cloud fraction *(marker)* and the range from minimum to maximum circle cloud fraction *(vertical line)*.
+### Time series of circle cloud cover
+We display the daily mean of all circle cloud cover *(marker)* and the range from minimum to maximum circle cloud cover *(vertical line)*.
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots(figsize=(10, 5))
 ts = np.timedelta64(2, 'h')
-for k, v in data.items():
-    ds = cf_circles(v)
-    ds["date"] = ds.time.astype('<M8[D]')
-    date = np.unique(ds.date) + ts
-    ax.errorbar(x=np.unique(ds.date) + ts,
-                y=ds.groupby("date").mean().CF_min.values,
-                yerr=[ds.groupby("date").min().CF_min.values,
-                      ds.groupby("date").max().CF_min.values],
-                fmt='o', color=colors[k], label=k)
-    ts += np.timedelta64(4, 'h')
-ax.set_ylim(0, 1)
-ax.set_xticks(np.unique(ds.date) + np.timedelta64(12, 'h'))
-ax.xaxis.set_major_formatter(mpl.dates.DateFormatter('%m-%d'))
-fig.autofmt_xdate()
 
-ax.spines['right'].set_visible(False)
-ax.spines['top'].set_visible(False)
+with plt.style.context("mplstyle/wide"):
+    fig, ax = plt.subplots()
+    for k, v in data.items():
+        ds = cf_circles(v)
+        ds["date"] = ds.time.astype('<M8[D]')
+        ax.errorbar(
+            x=np.unique(ds.date) + ts,
+            y=ds.groupby("date").mean().CF_min.values,
+            yerr=abs(np.array([ds.groupby("date").min().CF_min.values,
+                               ds.groupby("date").max().CF_min.values])
+                     - ds.groupby("date").mean().CF_min.values),
+            fmt='o',
+            color=colors[k],
+            label=k,
+        )
+        ts += np.timedelta64(4, 'h')
+    ax.set_ylim(0, 1)
+    ax.set_xticks(np.unique(ds.date) + np.timedelta64(12, 'h'))
+    ax.xaxis.set_major_formatter(mpl.dates.DateFormatter('%b %d'))
+    fig.autofmt_xdate()
 
-ax.set_ylabel("Cloud fraction")
-ax.legend(title="Instruments", bbox_to_anchor=(1,1), loc="upper left")
+    ax.spines['right'].set_visible(False)
+    ax.spines['top'].set_visible(False)
+
+    ax.set_ylabel("Minimum circle-mean\ncloud cover")
+    #ax.legend(title="Instruments", bbox_to_anchor=(1,1), loc="upper left")
+    ax.text(np.datetime64("2020-01-15T00:00:00"), ax.get_ylim()[1], "(c)",
+            verticalalignment='center')
+    ax.set_xlabel("Date")
 ```
 
 ```{raw-cell}

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -4,11 +4,13 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.12
-    jupytext_version: 1.7.1
+    jupytext_version: 1.8.0
 kernelspec:
   display_name: Python 3
   language: python
   name: python3
+execution:
+  timeout: 300
 ---
 
 # Cloud masks
@@ -181,8 +183,6 @@ this dataset is only available for the following application on February 5, not 
 ```
 
 ```{code-cell} ipython3
-import ipfsspec
-
 ds_bt = xr.open_zarr("ipfs://QmQEwkhhHdJkiThf4hnj9G3wgqVreBnWGrX2A5kT6CrtY7",
                      consolidated=True,
                     ).assign_coords(va=lambda x: x.va)
@@ -462,9 +462,6 @@ with plt.style.context("mplstyle/wide"):
     ax.set_xticks(np.unique(ds.date) + np.timedelta64(12, 'h'))
     ax.xaxis.set_major_formatter(mpl.dates.DateFormatter('%b %d'))
     fig.autofmt_xdate()
-
-    ax.spines['right'].set_visible(False)
-    ax.spines['top'].set_visible(False)
 
     ax.set_ylabel("Minimum circle-mean\ncloud cover")
     #ax.legend(title="Instruments", bbox_to_anchor=(1,1), loc="upper left")

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -403,24 +403,25 @@ binmids = (binedges[1:] + binedges[:-1]) / 2
 
 ```{code-cell} ipython3
 with plt.style.context("mplstyle/wide"):
-    fig, (ax, ax1) = plt.subplots(1, 2, sharey=True)
+    fig, (ax0, ax1) = plt.subplots(1, 2, sharey=True)
     for k, v in data.items():
-        ax.plot(binmids, np.histogram(cf_circles(v).CF_min.values, bins=binedges)[0],
+        ds = cf_circles(v)
+        ax0.plot(binmids, np.histogram(ds.CF_min.values, bins=binedges)[0],
                 ls="-", lw=2, marker=".", color=colors[k], label=k)
-        ax1.plot(binmids, np.histogram(cf_circles(v).CF_max.values, bins=binedges)[0],
+        ax1.plot(binmids, np.histogram(ds.CF_max.values, bins=binedges)[0],
                 ls="-", lw=2, marker=".", color=colors[k], label=k)
 
 
-    for a in [ax, ax1]:
-        a.set_xlim(0, 1)
-        a.set_ylim(0, 48)
-        a.set_xlabel("Cloud fraction")
-    ax.set_ylabel("Frequency")
-    ax.legend(title="Instruments")#, bbox_to_anchor=(1,1), loc="upper left")
-```
+    for ax in [ax0, ax1]:
+        ax.set_xlim(0, 1)
+        ax.set_ylim(0, max(ax0.get_ylim()[1], ax1.get_ylim()[1]))
+    ax0.set_xlabel("Minimum circle-mean cloud cover")
+    ax1.set_xlabel("Maximum circle-mean cloud cover")
+    ax0.set_ylabel("Number of circles")
+    ax0.legend(title="Instruments", bbox_to_anchor=(.55,1), loc="upper left")
 
-```{raw-cell}
-fig.savefig("Cloud_masks_distribution.png", bbox_inches="tight")
+    ax0.text(-0.12, ax.get_ylim()[1], "(a)", verticalalignment='top')
+    ax1.text(-0.1, ax.get_ylim()[1], "(b)", verticalalignment='top')
 ```
 
 ### Time series of circle cloud fraction

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -183,6 +183,8 @@ this dataset is only available for the following application on February 5, not 
 ```
 
 ```{code-cell} ipython3
+import ipfsspec
+
 ds_bt = xr.open_zarr("ipfs://QmQEwkhhHdJkiThf4hnj9G3wgqVreBnWGrX2A5kT6CrtY7",
                      consolidated=True, storage_options={'normalize_keys': False}
                     ).assign_coords(va=lambda x: x.va)

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -81,7 +81,8 @@ from multiprocessing.pool import ThreadPool
 def load_cloudmask_dataset(cat_item):
     # load in parallel as this function is mainly limited by the network roundtrip time
     p = ThreadPool(20)
-    return ensure_cfminmax(xr.concat(list(p.map(lambda v: v.get().to_dask().chunk(), cat_item.values())),
+    return ensure_cfminmax(xr.concat(list(p.map(lambda v: v.get().to_dask().chunk(),
+                                                cat_item.values())),
                                      dim="time"))
 ```
 
@@ -299,8 +300,8 @@ with plt.style.context("mplstyle/square"):
     ax2.set_ylabel("view angle / deg")
 
     # VELOX brightness temperature
-    im3 = (ds_bt.Brightness_temperature - 273.15).plot.pcolormesh(ax=ax3, x="time", y="va", cmap="RdYlBu_r",
-                           rasterized=True, add_colorbar=False)
+    im3 = (ds_bt.Brightness_temperature - 273.15).plot.pcolormesh(ax=ax3, x="time", y="va",
+            cmap="RdYlBu_r", rasterized=True, add_colorbar=False)
     cax3 = make_axes_locatable(ax3).append_axes("right", size="1%", pad=-0.05)
     fig.colorbar(im3, cax=cax3, label="Brightness\ntemperature / °C")
     ax3.set_ylabel("view angle / deg")
@@ -340,7 +341,8 @@ with plt.style.context("mplstyle/square"):
         ax.set_title("")
 
     axL6.set_xlabel("UTC time")
-    axL6.set_xticks(np.arange(np.datetime64('2020-02-05T11:22:00'), np.datetime64('2020-02-05T11:28:00'), np.timedelta64(1, 'm')))
+    axL6.set_xticks(np.arange(np.datetime64('2020-02-05T11:22:00'),
+                    np.datetime64('2020-02-05T11:28:00'), np.timedelta64(1, 'm')))
     ax0.xaxis.set_major_formatter(mpl.dates.DateFormatter('%H:%M'))
     fig.autofmt_xdate()
 
@@ -368,8 +370,8 @@ def cf_circles(ds):
     return xr.concat(
         [
             xr.Dataset({
-                "CF_max": ds.sel(time=slice(i["start"], i["end"])).CF_max.mean(dim="time", skipna=True),
-                "CF_min": ds.sel(time=slice(i["start"], i["end"])).CF_min.mean(dim="time", skipna=True),
+                "CF_max": ds.sel(time=slice(i["start"], i["end"])).CF_max.mean(dim="time"),
+                "CF_min": ds.sel(time=slice(i["start"], i["end"])).CF_min.mean(dim="time"),
                 "time": xr.DataArray(midpoint(i["start"], i["end"]), dims=()),
                 "segment_id": xr.DataArray(i["segment_id"], dims=())
             })

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -252,39 +252,39 @@ plt.style.use(["./mplstyle/book"])
 
 ```{code-cell} ipython3
 with plt.style.context("mplstyle/square"):
-    fig, (axV, axVb, axH, ax3, axP, axL1, axL2, axL3, axL4, axL5, axL6) = plt.subplots(
-        11, 1, sharex=True,# figsize=(10, 10),
-        gridspec_kw={"height_ratios": [3, 3, 3, 3, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]}
+    fig, (ax0, ax1, ax2, ax3, axLegend, axL1, axL2, axL3, axL4, axL5, axL6) = plt.subplots(
+        11, 1, sharex=True, gridspec_kw={"height_ratios": [3, 3, 3, 3, 0.5, 0.5, 0.5,
+                                                           0.5, 0.5, 0.5, 0.5]}
     )
 
     ## 2D vertical
     # Wales backscatter ratio
     im0 = da_bsri.plot.pcolormesh(
-        ax=axV, x="time", y="height", norm=LogNorm(vmin=1, vmax=100),
+        ax=ax0, x="time", y="height", norm=LogNorm(vmin=1, vmax=100),
         cmap="Spectral_r", rasterized=True, add_colorbar=False
     )
-    cax0 = make_axes_locatable(axV).append_axes("right", size="1%", pad=-0.05)
+    cax0 = make_axes_locatable(ax0).append_axes("right", size="1%", pad=-0.05)
     fig.colorbar(im0, cax=cax0, label="backscatter ratio", extend='both')
     # cloud top height
-    da_cth.plot(ax=axV, x="time", ls="", marker=".", color="k", label="Cloud top")
-    axV.legend()
+    da_cth.plot(ax=ax0, x="time", ls="", marker=".", color="k", label="Cloud top")
+    ax0.legend()
 
     # Radar reflectivity
-    im1 = da_radar.plot(ax=axVb, x="time", add_colorbar=False)
-    cax1 = make_axes_locatable(axVb).append_axes("right", size="1%", pad=-0.05)
+    im1 = da_radar.plot(ax=ax1, x="time", rasterized=True, add_colorbar=False)
+    cax1 = make_axes_locatable(ax1).append_axes("right", size="1%", pad=-0.05)
     fig.colorbar(im1, cax=cax1, label="reflectivity / dBZ")
 
-    for ax in [axV, axVb]:
+    for ax in [ax0, ax1]:
         ax.set_yticks([0, 1000, 2000, 3000])
         ax.set_ylabel("height / m")
 
     ## 2D horizontal
     # SpecMACS radiance
-    im2 = da_swir.plot.pcolormesh(ax=axH, x="time", y="angle", cmap="Greys_r",
+    im2 = da_swir.plot.pcolormesh(ax=ax2, x="time", y="angle", cmap="Greys_r",
                                   vmin=0, vmax=20, rasterized=True, add_colorbar=False)
-    cax2 = make_axes_locatable(axH).append_axes("right", size="1%", pad=-0.05)
+    cax2 = make_axes_locatable(ax2).append_axes("right", size="1%", pad=-0.05)
     fig.colorbar(im2, cax=cax2, label="SWIR radiance", extend='max')
-    axH.set_ylabel("view angle / deg")
+    ax2.set_ylabel("view angle / deg")
 
     # VELOX brightness temperature
     im3 = (ds_bt.Brightness_temperature - 273.15).plot.pcolormesh(ax=ax3, x="time", y="va", cmap="RdYlBu_r",
@@ -293,17 +293,18 @@ with plt.style.context("mplstyle/square"):
     fig.colorbar(im3, cax=cax3, label="Brightness\ntemperature / °C")
     ax3.set_ylabel("view angle / deg")
 
+
     ## We leave an empty axis to put the legend here
-    [s.set_visible(False) for s in axP.spines.values()]
-    axP.xaxis.set_visible(False)
-    axP.yaxis.set_visible(False)
+    [s.set_visible(False) for s in axLegend.spines.values()]
+    axLegend.xaxis.set_visible(False)
+    axLegend.yaxis.set_visible(False)
 
     ## 1D
     # We plot 1D cloud masks
     # Each we annotate with a total min and max cloud fraction for the scene shown and 
     # remove disturbing spines
     lines = []
-    plot_order = ['WALES', 'HAMP Radar', 'specMACS', 'HAMP Radiometer', 'KT19', 'VELOX']
+    plot_order = ['WALES', 'HAMP Radar', 'specMACS', 'VELOX', 'KT19', 'HAMP Radiometer']
     axes = dict(zip(plot_order, [axL1, axL2, axL3, axL4, axL5, axL6]))
 
     for k in plot_order:
@@ -322,14 +323,21 @@ with plt.style.context("mplstyle/square"):
     axL1.legend(lines, labels, ncol=7, bbox_to_anchor=(0.01, 1.5))
     axL3.set_ylabel("cloud flag")
 
-    for ax in [axV, axVb, axH, ax3, axP, axL1, axL2, axL3, axL4, axL5, axL6]:
-        if ax!=axL6:
-            ax.set_xlabel("")
+    for ax in [ax0, ax1, ax2, ax3, axLegend, axL1, axL2, axL3, axL4, axL5, axL6]:
+        ax.set_xlabel("")
         ax.set_title("")
-```
 
-```{raw-cell}
-fig.savefig("Cloud_masks_example_scene.png", bbox_inches="tight")
+    axL6.set_xlabel("UTC time")
+    axL6.set_xticks(np.arange(np.datetime64('2020-02-05T11:22:00'), np.datetime64('2020-02-05T11:28:00'), np.timedelta64(1, 'm')))
+    ax0.xaxis.set_major_formatter(mpl.dates.DateFormatter('%H:%M'))
+    fig.autofmt_xdate()
+
+    fig.align_ylabels(axs=[ax0, ax1, ax2, ax3, axL3])
+    #fig.align_ylabels(axs=[cax0, cax1, cax2])
+
+    label_pos_x = np.datetime64('2020-02-05T11:21:35')
+    for ax, label in zip([ax0, ax1, ax2, ax3, axL1], ["(a)", "(b)", "(c)", "(d)", "(e)"]):
+        ax.text(label_pos_x, ax.get_ylim()[1], label, verticalalignment='bottom')
 ```
 
 ## Statistical comparison

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -187,14 +187,22 @@ ds_bt = xr.open_zarr("ipfs://QmQEwkhhHdJkiThf4hnj9G3wgqVreBnWGrX2A5kT6CrtY7",
                     ).assign_coords(va=lambda x: x.va)
 ```
 
+What is the angle of the 11 central pixel in accross track direction?
+
+```{code-cell} ipython3
+xmid = ds_bt.x.size // 2
+va_central = ds_bt.isel(time=0, x=slice(xmid - 5, xmid + 6)).va
+(va_central.max() - va_central.min()).values
+```
+
 #### Preprocess cloud mask data
 
 We copy the data dictionary and apply the time selection.
 
 +++
 
-For the 2D horizontal imagers we select a region in the center, derive a representative `cloud_mask` flag value and use that in the following intercomparison plot.
-* VELOX: we select only the cetral 10 x 10 pixels
+For the 2D horizontal imagers we select a region in the center, derive a representative (most frequent) `cloud_mask` flag value and use that in the following intercomparison plot.
+* VELOX: we select only the cetral 11 x 11 pixels, i.e. view angle = 0 ∓ 0.2865
 * SpecMACS: we select the central 0.6 degrees, i.e. angle = 0 ∓ 0.3
 
 ```{code-cell} ipython3
@@ -214,7 +222,7 @@ def select_specmacs_cloudmask(ds):
 def select_velox_cloudmask(ds):
     xmid = ds.x.size // 2
     ymid = ds.y.size // 2
-    velox = ds.isel(x=slice(xmid - 5, xmid + 5), y=slice(ymid - 5, ymid + 5))
+    velox = ds.isel(x=slice(xmid - 5, xmid + 6), y=slice(ymid - 5, ymid + 6))
     return ds.assign({"cloud_mask": most_frequent_flag(velox.cloud_mask, ("x", "y")),
                       "CF_min": cfmin(velox),
                       "CF_max": cfmax(velox)})

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -108,6 +108,13 @@ cat_cloudmask = {
 data = {k: load_cloudmask_dataset(v) for k, v in cat_cloudmask.items()}
 ```
 
+We have a look at the time periods spanned by the individual datasets: The datasets `HAMP Radar`, `HAMP Radiometer`, and `specMACS` include measurements from the transfer flights on 19 January to Barbados and on 18 February back over the Atlantic to Europe. The datasets `WALES`, `KT19`, and `VELOX` are limited to the 13 local research flights between 22 January and 15 February.
+
+```{code-cell} ipython3
+for k, v in data.items():
+    print(f"{k}: {v.isel(time=0).time.values} -  {v.isel(time=-1).time.values}")
+```
+
 ## Case study on February 5
 We show the cloud masks from the various instruments for an 5 minute time interval around noon on February 5.
 
@@ -461,13 +468,26 @@ with plt.style.context("mplstyle/wide"):
     ax.set_xlabel("Date")
 ```
 
-```{raw-cell}
-fig.savefig("Cloud_masks_timeseries.png", bbox_inches="tight")
-```
-
-## Camapign mean cloud fraction
+## Camapign mean cloud cover
+* from all available data including the transfer flights
 
 ```{code-cell} ipython3
+print("Instrument: min - max")
+print("")
 for k, v in data.items():
-    print(f"{k}: {v.CF_max.mean().values:.2f}")
+    print(f"{k}: {v.CF_min.mean().values:.2f} - {v.CF_max.mean().values:.2f} ")
+```
+
+* only from local research flights
+
+```{code-cell} ipython3
+rf = slice(datetime.datetime(2020, 1, 22, 0, 0, 0),
+           datetime.datetime(2020, 2, 15, 23, 59, 59))
+```
+
+```{code-cell} ipython3
+print("Instrument: min - max")
+print("")
+for k, v in data.items():
+    print(f"{k}: {v.sel(time=rf).CF_min.mean().values:.2f} - {v.sel(time=rf).CF_max.mean().values:.2f} ")
 ```

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -37,10 +37,10 @@ import warnings
 warnings.filterwarnings("ignore")
 ```
 
-## Cloud fraction functions
+## Cloud cover functions
 We define some utility functions to extract (circle) cloud cover estimates from different datasets assuming that the datasets follow a certain flag meaning convention.  
 
-In particular, we define a **minimum cloud fraction** based on the cloud mask flag `most_likely_cloudy` and a **maximum cloud fraction** combining the flags `most_likely_cloudy` and `probably_cloudy`. The cloud mask datasets slightly vary in their flag definition for cloud free conditions and their handling of unvalid measurements which is taken care of by the following functions.
+In particular, we define a **minimum cloud cover** based on the cloud mask flag `most_likely_cloudy` and a **maximum cloud cover** combining the flags `most_likely_cloudy` and `probably_cloudy`. The cloud mask datasets slightly vary in their flag definition for cloud free conditions and their handling of unvalid measurements which is taken care of by the following functions.
 
 ```{code-cell} ipython3
 def _isvalid(da):
@@ -195,17 +195,17 @@ We copy the data dictionary and apply the time selection.
 
 +++
 
-What is the angle of the 11 central pixel in accross track direction?
+For the 2D horizontal imagers we select a region in the center, derive a representative (most frequent) `cloud_mask` flag value and use that in the following intercomparison plot.
+* VELOX: we select only the central 11 x 11 pixels, i.e. view angle = 0 ∓ 0.2865 (see below)
+* SpecMACS: we select the central 0.6 degrees, i.e. angle = 0 ∓ 0.3
+
+What is the angle of the 11 central pixel in accross track direction for VELOX?
 
 ```{code-cell} ipython3
 xmid = ds_bt.x.size // 2
 va_central = ds_bt.isel(time=0, x=slice(xmid - 5, xmid + 6)).va
 (va_central.max() - va_central.min()).values
 ```
-
-For the 2D horizontal imagers we select a region in the center, derive a representative (most frequent) `cloud_mask` flag value and use that in the following intercomparison plot.
-* VELOX: we select only the cetral 11 x 11 pixels, i.e. view angle = 0 ∓ 0.2865
-* SpecMACS: we select the central 0.6 degrees, i.e. angle = 0 ∓ 0.3
 
 ```{code-cell} ipython3
 def most_frequent_flag(var, dims):
@@ -314,7 +314,7 @@ with plt.style.context("mplstyle/square"):
 
     ## 1D
     # We plot 1D cloud masks
-    # Each we annotate with a total min and max cloud fraction for the scene shown and 
+    # Each we annotate with a total min and max cloud cover for the scene shown and
     # remove disturbing spines
     lines = []
     plot_order = ['WALES', 'HAMP Radar', 'specMACS', 'VELOX', 'KT19', 'HAMP Radiometer']
@@ -356,11 +356,11 @@ with plt.style.context("mplstyle/square"):
 
 ## Statistical comparison
 
-We will further compare cloud mask information from all HALO flights during EUREC4A on the basis of circle flight segments. Most of the time, the HALO aircraft sampled the airmass in circles east of Barbados. We use the meta data on flight segments, extract the information on start and end time of individual circles, and derive circle-average cloud fractions.
+We will further compare cloud mask information from all HALO flights during EUREC4A on the basis of circle flight segments. Most of the time, the HALO aircraft sampled the airmass in circles east of Barbados. We use the meta data on flight segments, extract the information on start and end time of individual circles, and derive circle-average cloud cover.
 
 For the 2D imagers VELOX and speMACS we use the full swath. In the case study above we had selected the central measurements for a better comparison with the other instruments. However, in the following we investigate the broad statistics and therefore include as much information on the cloud field as we can get from the full footprints of each instrument.
 
-The following statistics are based on the **maximum cloud fraction** with cloud mask flags $\in$ {`most_likely_cloudy`, `probably_cloudy`}.
+The following statistics are based on the **maximum cloud cover** with cloud mask flags $\in$ {`most_likely_cloudy`, `probably_cloudy`}.
 
 ```{code-cell} ipython3
 def midpoint(a, b):
@@ -408,7 +408,7 @@ segments = {s["segment_id"]: {**s, "flight_id": flight["flight_id"]}
 print(f"In total HALO flew {len(segments)} circles during EUREC4A")
 ```
 
-### Histogram of circle mean cloud fraction
+### Histogram of circle mean cloud cover
 
 ```{code-cell} ipython3
 binedges = np.arange(0, 1.2, .2)
@@ -473,7 +473,7 @@ with plt.style.context("mplstyle/wide"):
 ```
 
 ### A small interpretation
-A few features stick out in the above figures showing the statistics:
+A few features stick out in the above figures showing the cloud cover statistics:
 * the WALES dataset does not have a `probably_cloudy` flag, and thus, the `CF_min` and `CF_max` variables are the same. The instrument design and methodology used to define the cloud flag seems to be very sensitive to small and optically thin clouds and the cloud cover estimates agree better with the `CF_max` of all other instruments.
 * All instruments, excluding WALES, agree well in the distribution of circle-mean cloud cover estimates according to their `CF_min` variable, while they vary on their definition of uncertain `probably_cloudy` measurements that are included in `CF_max`.
 * On the transfer flight on 19 January the HAMP radar and radiometer and specMACS datasets were processed and datasets are available including one circle near Barbados. For WALES, VELOX, and KT19 no data is available.

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -128,8 +128,7 @@ We add 2D vertical lidar and radar data, as well as 2D horizontal imager data fo
 #### Time interval
 
 ```{code-cell} ipython3
-s = slice(datetime.datetime(2020, 2, 5, 11, 22, 0),
-          datetime.datetime(2020, 2, 5, 11, 27, 0))
+s = slice("2020-02-05T11:22:00", "2020-02-05T11:27:00")
 ```
 
 #### HAMP radar reflectivities
@@ -487,8 +486,7 @@ for k, v in data.items():
 * only from local research flights
 
 ```{code-cell} ipython3
-rf = slice(datetime.datetime(2020, 1, 22, 0, 0, 0),
-           datetime.datetime(2020, 2, 15, 23, 59, 59))
+localRF = slice("2020-01-22T00:00:00", "2020-02-15T23:59:59")
 ```
 
 ```{code-cell} ipython3

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -19,15 +19,10 @@ In the following, we compare the different cloud mask products for a case study 
 More information on the dataset can be found in Konow et al. (in preparation). If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
 ```{code-cell} ipython3
-%pylab inline
-```
-
-```{code-cell} ipython3
 import eurec4a
 import numpy as np
 import xarray as xr
 import matplotlib as mpl
-mpl.rcParams['font.size'] = 12
 
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.colors import LogNorm
@@ -250,82 +245,87 @@ colors={
 ```
 
 ```{code-cell} ipython3
-fig, (axV, axVb, axH, ax3, axP, axL1, axL2, axL3, axL4, axL5, axL6) = plt.subplots(
-    11, 1, sharex=True, figsize=(16, 12),
-    gridspec_kw={"height_ratios": [3, 3, 3, 3, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]}
-)
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.style.use(["./mplstyle/book"])
+```
 
-## 2D vertical
-# Wales backscatter ratio
-im0 = da_bsri.plot.pcolormesh(
-    ax=axV, x="time", y="height", norm=LogNorm(vmin=1, vmax=100),
-    cmap="Spectral_r", rasterized=True, add_colorbar=False
-)
-cax0 = make_axes_locatable(axV).append_axes("right", size="1%", pad=-0.05)
-fig.colorbar(im0, cax=cax0, label="backscatter ratio", extend='both')
-# cloud top height
-da_cth.plot(ax=axV, x="time", ls="", marker=".", color="k", label="Cloud top")
-axV.legend()
+```{code-cell} ipython3
+with plt.style.context("mplstyle/square"):
+    fig, (axV, axVb, axH, ax3, axP, axL1, axL2, axL3, axL4, axL5, axL6) = plt.subplots(
+        11, 1, sharex=True,# figsize=(10, 10),
+        gridspec_kw={"height_ratios": [3, 3, 3, 3, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]}
+    )
 
-# Radar reflectivity
-im1 = da_radar.plot(ax=axVb, x="time", add_colorbar=False)
-cax1 = make_axes_locatable(axVb).append_axes("right", size="1%", pad=-0.05)
-fig.colorbar(im1, cax=cax1, label="reflectivity / dBZ")
+    ## 2D vertical
+    # Wales backscatter ratio
+    im0 = da_bsri.plot.pcolormesh(
+        ax=axV, x="time", y="height", norm=LogNorm(vmin=1, vmax=100),
+        cmap="Spectral_r", rasterized=True, add_colorbar=False
+    )
+    cax0 = make_axes_locatable(axV).append_axes("right", size="1%", pad=-0.05)
+    fig.colorbar(im0, cax=cax0, label="backscatter ratio", extend='both')
+    # cloud top height
+    da_cth.plot(ax=axV, x="time", ls="", marker=".", color="k", label="Cloud top")
+    axV.legend()
 
-for ax in [axV, axVb]:
-    ax.set_yticks([0, 1000, 2000, 3000])
-    ax.set_ylabel("height / m")
+    # Radar reflectivity
+    im1 = da_radar.plot(ax=axVb, x="time", add_colorbar=False)
+    cax1 = make_axes_locatable(axVb).append_axes("right", size="1%", pad=-0.05)
+    fig.colorbar(im1, cax=cax1, label="reflectivity / dBZ")
 
-## 2D horizontal
-# SpecMACS radiance
-im2 = da_swir.plot.pcolormesh(ax=axH, x="time", y="angle", cmap="Greys_r",
-                              vmin=0, vmax=20, rasterized=True, add_colorbar=False)
-cax2 = make_axes_locatable(axH).append_axes("right", size="1%", pad=-0.05)
-fig.colorbar(im2, cax=cax2, label="SWIR radiance", extend='max')
-axH.set_ylabel("view angle / deg")
+    for ax in [axV, axVb]:
+        ax.set_yticks([0, 1000, 2000, 3000])
+        ax.set_ylabel("height / m")
 
-# VELOX brightness temperature
-im3 = (ds_bt.Brightness_temperature - 273.15).plot.pcolormesh(ax=ax3, x="time", y="va", cmap="RdYlBu_r",
-                       rasterized=True, add_colorbar=False)
-cax3 = make_axes_locatable(ax3).append_axes("right", size="1%", pad=-0.05)
-fig.colorbar(im3, cax=cax3, label="Brightness\ntemperature / °C")
-ax3.set_ylabel("view angle / deg")
+    ## 2D horizontal
+    # SpecMACS radiance
+    im2 = da_swir.plot.pcolormesh(ax=axH, x="time", y="angle", cmap="Greys_r",
+                                  vmin=0, vmax=20, rasterized=True, add_colorbar=False)
+    cax2 = make_axes_locatable(axH).append_axes("right", size="1%", pad=-0.05)
+    fig.colorbar(im2, cax=cax2, label="SWIR radiance", extend='max')
+    axH.set_ylabel("view angle / deg")
 
-## We leave an empty axis to put the legend here
-[s.set_visible(False) for s in axP.spines.values()]
-axP.xaxis.set_visible(False)
-axP.yaxis.set_visible(False)
+    # VELOX brightness temperature
+    im3 = (ds_bt.Brightness_temperature - 273.15).plot.pcolormesh(ax=ax3, x="time", y="va", cmap="RdYlBu_r",
+                           rasterized=True, add_colorbar=False)
+    cax3 = make_axes_locatable(ax3).append_axes("right", size="1%", pad=-0.05)
+    fig.colorbar(im3, cax=cax3, label="Brightness\ntemperature / °C")
+    ax3.set_ylabel("view angle / deg")
 
-## 1D
-# We plot 1D cloud masks
-# Each we annotate with a total min and max cloud fraction for the scene shown and 
-# remove disturbing spines
-lines = []
-plot_order = ['WALES', 'HAMP Radar', 'specMACS', 'HAMP Radiometer', 'KT19', 'VELOX']
-axes = dict(zip(plot_order, [axL1, axL2, axL3, axL4, axL5, axL6]))
+    ## We leave an empty axis to put the legend here
+    [s.set_visible(False) for s in axP.spines.values()]
+    axP.xaxis.set_visible(False)
+    axP.yaxis.set_visible(False)
 
-for k in plot_order:
-    ds = data_feb5[k]
-    lines += ds.cloud_mask.plot.line(ax=axes[k], x="time", label=k, color=colors[k])
-    if axes[k]!=axL6:
-        axes[k].spines["bottom"].set_visible(False)
-        axes[k].xaxis.set_visible(False)
-    axes[k].set_ylabel("")
-    axes[k].annotate(f"{ds.CF_min.mean().values * 100:.1f}"
-                     + f" - {ds.CF_max.mean().values * 100:.1f} %",
-                     (1, 0.5), color=colors[k], xycoords="axes fraction")
+    ## 1D
+    # We plot 1D cloud masks
+    # Each we annotate with a total min and max cloud fraction for the scene shown and 
+    # remove disturbing spines
+    lines = []
+    plot_order = ['WALES', 'HAMP Radar', 'specMACS', 'HAMP Radiometer', 'KT19', 'VELOX']
+    axes = dict(zip(plot_order, [axL1, axL2, axL3, axL4, axL5, axL6]))
 
-# We add one legend for all 1D cloud masks
-labels = [l.get_label() for l in lines]
-axL1.legend(lines, labels, ncol=7, bbox_to_anchor=(0.15, 1.1))
-axL3.set_ylabel("cloud flag")
+    for k in plot_order:
+        ds = data_feb5[k]
+        lines += ds.cloud_mask.plot.line(ax=axes[k], x="time", label=k, color=colors[k])
+        if axes[k]!=axL6:
+            axes[k].spines["bottom"].set_visible(False)
+            axes[k].xaxis.set_visible(False)
+        axes[k].set_ylabel("")
+        axes[k].annotate(f"{ds.CF_min.mean().values * 100:.1f}"
+                         + f" - {ds.CF_max.mean().values * 100:.1f} %",
+                         (1, 0.5), color=colors[k], xycoords="axes fraction")
 
-for ax in [axV, axVb, axH, ax3, axP, axL1, axL2, axL3, axL4, axL5, axL6]:
-    if ax!=axL6:
-        ax.set_xlabel("")
-    ax.set_title("")
-    ax.spines['right'].set_visible(False)
-    ax.spines['top'].set_visible(False)
+    # We add one legend for all 1D cloud masks
+    labels = [l.get_label() for l in lines]
+    axL1.legend(lines, labels, ncol=7, bbox_to_anchor=(0.01, 1.5))
+    axL3.set_ylabel("cloud flag")
+
+    for ax in [axV, axVb, axH, ax3, axP, axL1, axL2, axL3, axL4, axL5, axL6]:
+        if ax!=axL6:
+            ax.set_xlabel("")
+        ax.set_title("")
 ```
 
 ```{raw-cell}
@@ -394,23 +394,21 @@ binmids = (binedges[1:] + binedges[:-1]) / 2
 ```
 
 ```{code-cell} ipython3
-fig, (ax, ax1) = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
-for k, v in data.items():
-    ax.plot(binmids, np.histogram(cf_circles(v).CF_min.values, bins=binedges)[0],
-            ls="-", lw=2, marker=".", color=colors[k], label=k)
-    ax1.plot(binmids, np.histogram(cf_circles(v).CF_max.values, bins=binedges)[0],
-            ls="-", lw=2, marker=".", color=colors[k], label=k)
+with plt.style.context("mplstyle/wide"):
+    fig, (ax, ax1) = plt.subplots(1, 2, sharey=True)
+    for k, v in data.items():
+        ax.plot(binmids, np.histogram(cf_circles(v).CF_min.values, bins=binedges)[0],
+                ls="-", lw=2, marker=".", color=colors[k], label=k)
+        ax1.plot(binmids, np.histogram(cf_circles(v).CF_max.values, bins=binedges)[0],
+                ls="-", lw=2, marker=".", color=colors[k], label=k)
 
 
-for a in [ax, ax1]:
-    a.set_xlim(0, 1)
-    a.set_ylim(0, 48)
-    a.spines['right'].set_visible(False)
-    a.spines['top'].set_visible(False)
-
-    a.set_xlabel("Cloud fraction")
-ax.set_ylabel("Frequency")
-ax1.legend(title="Instruments", bbox_to_anchor=(1,1), loc="upper left")
+    for a in [ax, ax1]:
+        a.set_xlim(0, 1)
+        a.set_ylim(0, 48)
+        a.set_xlabel("Cloud fraction")
+    ax.set_ylabel("Frequency")
+    ax.legend(title="Instruments")#, bbox_to_anchor=(1,1), loc="upper left")
 ```
 
 ```{raw-cell}

--- a/how_to_eurec4a/mplstyle/square
+++ b/how_to_eurec4a/mplstyle/square
@@ -1,0 +1,1 @@
+figure.figsize: 10, 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pydap
 ipyleaflet
 simplification
 colorcet
+zarr>=2.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ eurec4a
 intake[dataframe] # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
 intake-xarray
 fsspec!=0.9.0 # 0.9.0 has a bug which leads to incomplete reads via HTTP
-ipfsspec>=0.0.2
+ipfsspec>=0.1.0
 requests
 aiohttp
 pydap


### PR DESCRIPTION
The plots from the cloud mask chapter shall be part of the EUREC4A HALO ESSD paper (in preparation). From an internal review among the co-authors a few suggestions were made that lead to an update here. The main points were:

* we added a VELOX brightness temperature image to the case study plot on Feb 5.
* for the same figure, the VELOX cloud flag was based on the central 10x10 pixels and was extended to 11x11 pixels (~0.57°) to better match the specMACS (central 0.6°) and radar footprints.
* the time series plot had a bug in the errorbar calculation that was fixed
* campaign mean averages shall cover only local research flights
* further clean up and improvements