### PR TITLE
Update to jb 0.11.0 with new toc structure

### DIFF
--- a/how_to_eurec4a/_toc.yml
+++ b/how_to_eurec4a/_toc.yml
@@ -1,39 +1,39 @@
-# Table of contents
-# Learn more at https://jupyterbook.org/customize/toc.html
-- file: intro
+format: jb-article
+root: intro
+sections:
 - file: halo
   sections:
-    - file: HALO_instrument_overview
-    - file: specmacs
-    - file: unified
-    - file: flight_tracks_leaflet
-    - file: smart
-    - file: velox
-    - file: bacardi
-    - file: wales
-    - file: hamp_comparison
-    - file: cloudmasks
+  - file: HALO_instrument_overview
+  - file: specmacs
+  - file: unified
+  - file: flight_tracks_leaflet
+  - file: smart
+  - file: velox
+  - file: bacardi
+  - file: wales
+  - file: hamp_comparison
+  - file: cloudmasks
 - file: pthree
   sections:
-    - file: p3_flight_tracks
-    - file: p3_humidity_comparison
-    - file: p3_wband_radar
-    - file: p3_AXBTs
-    - file: p3_wsra
+  - file: p3_flight_tracks
+  - file: p3_humidity_comparison
+  - file: p3_wband_radar
+  - file: p3_AXBTs
+  - file: p3_wsra
 - file: meteor
   sections:
-    - file: meteor_cloudradar
+  - file: meteor_cloudradar
 - file: merian
   sections:
-    - file: merian_cloudradar
+  - file: merian_cloudradar
 - file: multi_platform_data
   sections:
-    - file: dropsondes
+  - file: dropsondes
 - file: toolbox
   sections:
-    - file: flight-phase-operations
-    - file: show_intake_catalog
-    - file: running_locally
-    - file: netcdf_datatypes
+  - file: flight-phase-operations
+  - file: show_intake_catalog
+  - file: running_locally
+  - file: netcdf_datatypes
 - file: references
 - file: stats

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jupyter-book>0.9.0 # Pinned version of sphinxcontrib-bibtex
+jupyter-book>0.11.0 # New toc structure
 jupytext
 matplotlib
 numpy


### PR DESCRIPTION
The new jb version v0.11.0 has a new table of contents infrastructure. See the [webpage](https://jupyterbook.org/reference/_changelog.html) for more details. 