### PR TITLE
Update wales.md

### DIFF
--- a/how_to_eurec4a/wales.md
+++ b/how_to_eurec4a/wales.md
@@ -17,7 +17,7 @@ The water vapour differential absorption lidar WALES.
 WALES operates at four wave-lengths near 935 nm to measure water-vapor mixing ratio profiles covering the whole atmosphere below the aircraft.
 The system also contains additional aerosol channels at 532 nm and 1064 nm with depolarization.  WALES uses a high-spectral resolution technique, which distinguishes molecular from particle backscatter.
 
-At typical flight speeds of 200 m/s the backscatter product from the HSRL has a resolution of 200m in the horizontal and 15m in the vertical, while the water vapor product has approximately 3km horizontal and 250m vertical. The PIs during EUREC4A were Martin Wirth and Heike Gross (DLR).
+The backscatter product from the HSRL has a resolution of 40 m in the horizontal (corresponding to temporal resolution of 5 Hz and a typical 200 m/s flight speed) and 15m in the vertical, while the water vapor product has approximately 3km horizontal and 250m vertical. The PIs during EUREC4A were Martin Wirth and Heike Gross (DLR).
 
 More information on the instrument can be found in [Wirth et al., 2009](https://elib.dlr.de/58175/). If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 


### PR DESCRIPTION
There may be a slight typo about the horizontal resolution for the HSRL data. The horizontal resolution was given at 200 m for a typical 200 m/s flight speed, but I think the resolution is 5 Hz, which would correspond to 40 m horizontal resolution.

Sources: https://eurec4a.aeris-data.fr/landing-page/?uuid=ef3783b1-2ee6-4043-b088-5430ba486096
and quoted from [Konow et al, 2021](https://essd.copernicus.org/preprints/essd-2021-193/essd-2021-193.pdf), "For the WALES cloud mask lidar raw data at a temporal resolution of 5 Hz were used, which corresponds to 40 m horizontal spacing. The vertical resolution of the backscatter data is 7.5 m"