### PR TITLE
Fix dependency installation

### DIFF
--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -25,8 +25,6 @@ jobs:
         environment-file: environment.yml
         python-version: ${{ matrix.python-version }}
         auto-activate-base: false
-    - name: Install remaining dependencies with pip
-      run: pip install -r requirements.txt
     - name: build book
       run: |
         conda info

--- a/environment.yml
+++ b/environment.yml
@@ -4,3 +4,5 @@ dependencies:
   - anaconda
   - cartopy
   - pip
+  - pip:
+    - -r file:requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - cartopy
   - pip
   - pip:
-    - -r file:requirements.txt
+    - -r requirements.txt


### PR DESCRIPTION
pip-dependencies haven't been installed anymore on binder, because of a previous fix.
This PR (hopefully) fixes the root cause, which is pip beeing more strict about what the definition of a file-URI is.
In particular, it is not allowed to install dependecies via
```
pip install -r file:requirements.txt
```
but 
```
pip install -r requirements.txt
```
is still fine.

Due to this change, pip-dependencies can be again installed via conda and thus will also automatically be installed in binder again.