### PR TITLE
Update C3ONTEXT publication reference to published version

### DIFF
--- a/how_to_eurec4a/c3ontext.md
+++ b/how_to_eurec4a/c3ontext.md
@@ -41,7 +41,7 @@ dominant cloud patterns, can be retrieved along a platform track. In this partic
 the track of the R/V Meteor. The measurements made onboard the research vessel like cloud radar and Raman
 lidar can therefor be analysed and interpreted with respect to the four cloud patterns.
 
-More details on this dataset can be found in {cite}`Schulz:2021` and
+More details on this dataset can be found in {cite}`Schulz:2022` and
 in the [C<sup>3</sup>ONTEXT GitHub-repository](https://github.com/observingClouds/EUREC4A_manualclassifications).
 
 ## Accessing the data

--- a/how_to_eurec4a/references.bib
+++ b/how_to_eurec4a/references.bib
@@ -86,14 +86,15 @@ DOI = {10.5194/essd-2021-11}
 	year = "2020",
 }
 
-@article{Schulz:2021,
+@article{Schulz:2022,
   title = {{C3ONTEXT}: {{A Common Consensus}} on {{Convective OrgaNizaTion}} during the {{EUREC4A eXperimenT}}},
   shorttitle = {C{\textsuperscript{3}}{{ONTEXT}}},
   author = {Schulz, Hauke},
-  year = {2021},
-  journal = {Earth System Science Data Discussions},
-  pages = {1--27},
+  year = {2022},
+  journal = {Earth System Science Data},
+  volume = {14},
+  number = {3},
+  pages = {1233--1256},
   publisher = {{Copernicus GmbH}},
-  issn = {1866-3508},
-  doi = {10.5194/essd-2021-427},
+  doi = {10.5194/essd-14-1233-2022},
 }


### PR DESCRIPTION
Just a small update on the C3ONTEXT paper reference since the final paper is now published and should be cited instead of the preprint.