### PR TITLE
Change spelling of EUREC4A to EUREC⁴A

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,14 +25,14 @@ and "help wanted" is open to whoever wants to implement it.
 
 ## Write Documentation
 
-How to EUREC4A could always use more documentation, whether as part of the
-official How to EUREC4A docs, in docstrings, or even on the web in blog posts,
+How to EUREC⁴A could always use more documentation, whether as part of the
+official How to EUREC⁴A docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
 
 ## Get Started
 
-Ready to contribute? Here's how to set up `How to EUREC4A` for local development.
+Ready to contribute? Here's how to set up `How to EUREC⁴A` for local development.
 
 1. Fork the repo on GitHub.
 2. Clone your fork locally.
@@ -57,4 +57,4 @@ A fully-rendered HTML version of the book will be built in `how_to_eurec4a/_buil
 
 ## Code of Conduct
 
-Please note that the How to EUREC4A project is released with a [Contributor Code of Conduct](CONDUCT.md). By contributing to this project you agree to abide by its terms.
+Please note that the How to EUREC⁴A project is released with a [Contributor Code of Conduct](CONDUCT.md). By contributing to this project you agree to abide by its terms.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021, EUREC4A community
+Copyright (c) 2021, EUREC⁴A community
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# How to EUREC4A
+# How to EUREC⁴A
 
-EUREC4A offers a wealth of data!
+EUREC⁴A offers a wealth of data!
 This book shall provide some help in finding and working with different datasets. Example scripts mainly show the access and basic plots of dataset variables.
 
 **The most recent version of the book is linked [here](https://howto.eurec4a.eu/).**

--- a/how_to_eurec4a/HALO_instrument_overview.md
+++ b/how_to_eurec4a/HALO_instrument_overview.md
@@ -4,7 +4,7 @@ The instrumentation of the HALO aircraft is based on contributions from various 
 Each instrument is developed and operated by an individual group, which leads to a modern instrumentation suite and well trained operators, but also requires to contact a range of people when working with data from HALO's instruments.
 The purpose of this chapter is to introduce you to the individual contact points.
 
-During the EUREC4A field campaign, the HALO aircraft had been outfitted in an updated "Cloud Observatory" configuration, much like as described by {cite}`Stevens:2019`.
+During the EUREC⁴A field campaign, the HALO aircraft had been outfitted in an updated "Cloud Observatory" configuration, much like as described by {cite}`Stevens:2019`.
 As the aircraft is build to be flying at high altitudes, most of the instrumentation observes the atmosphere (and in particular clouds) from the nadir perspective.
 
 ```{figure} figures/HALO_details.png
@@ -12,7 +12,7 @@ As the aircraft is build to be flying at high altitudes, most of the instrumenta
 :width: 600px
 :align: center
 
-Instruments on HALO as configured for the EUREC4A campaign.
+Instruments on HALO as configured for the EUREC⁴A campaign.
 ```
 
 In particular, the instrumentation consists of broadband radiometers (**BACARDI**), basic instrumentation (**BAHAMAS**), a dropsonde launching system (**Dropsondes**), the active (radar) and passive microwave package (**HAMP**), irradiance spectrometers (**SMART**), a thermal imager (**VELOX**), an infrared radiometer (**VELOX-KT19**), a water vapor differential absorption lidar (**WALES**) and spectral and polarization resolving imagers (**specMACS**).

--- a/how_to_eurec4a/_config.yml
+++ b/how_to_eurec4a/_config.yml
@@ -5,8 +5,8 @@
 
 #######################################################################################
 # Book settings
-title                       : How to EUREC4A      # The title of the book. Will be placed in the left navbar.
-author                      : EUREC4A community   # The author of the book
+title                       : How to EUREC⁴A      # The title of the book. Will be placed in the left navbar.
+author                      : EUREC⁴A community   # The author of the book
 copyright                   : "2021"              # Copyright year to be placed in the footer
 logo                        : logo_pyeurec4a.png  # A path to the book logo
 repository:

--- a/how_to_eurec4a/bacardi.md
+++ b/how_to_eurec4a/bacardi.md
@@ -18,7 +18,7 @@ The following script exemplifies the access and usage of the Broadband AirCrAft 
 The dataset is published under [Ehrlich et al. (2021)](https://doi.org/10.25326/160). If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
 ## Get data
-* To load the data we first load the EUREC4A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
+* To load the data we first load the EUREC⁴A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
 
 ```{code-cell} ipython3
 import eurec4a
@@ -40,7 +40,7 @@ ds = cat.HALO.BACARDI.irradiances['HALO-0205'].to_dask()
 ds
 ```
 
-The data from EUREC4A is of 10 Hz measurement frequency and corrected for dynamic temperature effects. For the downward solar irradiance, data are provided with and without aircraft attitude correction corresponding to cloud-free and cloudy conditions, respectively, above HALO.
+The data from EUREC⁴A is of 10 Hz measurement frequency and corrected for dynamic temperature effects. For the downward solar irradiance, data are provided with and without aircraft attitude correction corresponding to cloud-free and cloudy conditions, respectively, above HALO.
 
 +++
 

--- a/how_to_eurec4a/c3ontext.md
+++ b/how_to_eurec4a/c3ontext.md
@@ -32,7 +32,7 @@ Both rule-based algorithms and deep neural networks have been developed to ident
 patterns automatically to learn more about their characteristics and processes.
 For the time period of the EUREC<sup>4</sup>A campaign, a group of 50 participants
 has identified these meso-scale patterns manually on satellite images. Their classifications build
-the *Common Consensus on Convective OrgaNizaTionduring the EUREC4A eXperimenT* dataset, short
+the *Common Consensus on Convective OrgaNizaTionduring the EUREC⁴A eXperimenT* dataset, short
 **C<sup>3</sup>ONTEXT**.
 
 As the acronym already suggests, the dataset is meant to provide the meso-scale *context* to additional

--- a/how_to_eurec4a/cloudmasks.md
+++ b/how_to_eurec4a/cloudmasks.md
@@ -15,7 +15,7 @@ execution:
 
 # Cloud masks
 
-Different instruments, by virtue of their differing measurement principle and footprint, see clouds in different ways. To provide an overview of the cloud fields sampled by HALO during EUREC4A, a cloud mask is created for each cloud sensitive instrument.  
+Different instruments, by virtue of their differing measurement principle and footprint, see clouds in different ways. To provide an overview of the cloud fields sampled by HALO during EUREC⁴A, a cloud mask is created for each cloud sensitive instrument.  
 In the following, we compare the different cloud mask products for a case study on 5 February and further provide a statistical overview for the full campaign period.
 
 More information on the dataset can be found in Konow et al. (in preparation). If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
@@ -355,7 +355,7 @@ with plt.style.context("mplstyle/square"):
 
 ## Statistical comparison
 
-We will further compare cloud mask information from all HALO flights during EUREC4A on the basis of circle flight segments. Most of the time, the HALO aircraft sampled the airmass in circles east of Barbados. We use the meta data on flight segments, extract the information on start and end time of individual circles, and derive circle-average cloud cover.
+We will further compare cloud mask information from all HALO flights during EUREC⁴A on the basis of circle flight segments. Most of the time, the HALO aircraft sampled the airmass in circles east of Barbados. We use the meta data on flight segments, extract the information on start and end time of individual circles, and derive circle-average cloud cover.
 
 For the 2D imagers VELOX and speMACS we use the full swath. In the case study above we had selected the central measurements for a better comparison with the other instruments. However, in the following we investigate the broad statistics and therefore include as much information on the cloud field as we can get from the full footprints of each instrument.
 

--- a/how_to_eurec4a/dropsondes.md
+++ b/how_to_eurec4a/dropsondes.md
@@ -14,13 +14,13 @@ kernelspec:
 # Dropsondes dataset JOANNE
 
 The following script exemplifies the access and usage of dropsonde data measured 
-during EUREC4A - ATOMIC.  
+during EUREC⁴A - ATOMIC.  
 
 More information on the dataset can be found at https://github.com/Geet-George/JOANNE/tree/master/joanne/Level_3#level---3.
 If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` and `author`.
 
 ## Get data
-* To load the data we first load the EUREC4A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
+* To load the data we first load the EUREC⁴A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
 
 ```{code-cell} ipython3
 import datetime

--- a/how_to_eurec4a/flight-phase-operations.md
+++ b/how_to_eurec4a/flight-phase-operations.md
@@ -86,7 +86,7 @@ segment_ids_by_kind = {kind: [segment["segment_id"]
 ```
 
 ## 5. Further random examples:
-* total number of all circles flown during EUREC4A / ATOMIC
+* total number of all circles flown during EUREC⁴A / ATOMIC
 
 ```{code-cell} ipython3
 len(segment_ids_by_kind["circle"])

--- a/how_to_eurec4a/halo.md
+++ b/how_to_eurec4a/halo.md
@@ -3,7 +3,7 @@
 The German High Altitude and Long-Range Research Aircraft (HALO) operated by the Deutsches Zentrum für Luft- and Raumfahrt (DLR) was equiped with remote sensing instruments and a facility to launch dropsondes. All instruments and PIs are listed on the official [eurec4a](http://eurec4a.eu/platforms/halo) webpage.
 
 
-During EUREC4A HALO flew most of the time at about 9 km altitude circular patterns with 200 km diameter centered at 57.72W, 13.30N.
+During EUREC⁴A HALO flew most of the time at about 9 km altitude circular patterns with 200 km diameter centered at 57.72W, 13.30N.
 On typical flight days an excursion to the NTAS buoy or a satellite underpass separated the first three from the remaining three circles. Typically, the aircraft stayed up in the air for 8-9 hours per day starting at varying times in the morning to capture the diurnal cycle.
 
 ```{figure} halo.jpg

--- a/how_to_eurec4a/intro.md
+++ b/how_to_eurec4a/intro.md
@@ -1,11 +1,11 @@
 # Introduction
 
-Welcome to the world of EUREC4A data!
+Welcome to the world of EUREC⁴A data!
 This is a collection of python code examples to get you started with the data.
 
 ## Idea
-The book chapters show datasets that are accessible online, i.e. you don't have to download anything. Most datasets are accessed via the [eurec4a intake catalog](https://github.com/eurec4a/eurec4a-intake), which simply said takes care of the links to datasets in their most recent version.
-The scripts typically contain at minimum how to get a specific dataset and some simple plots of basic quantities. Most chapters include additional information from aircraft flight segments or further eurec4a meta data, sometimes more sophisticated plots, or also a combination of variables from different datasets.
+The book chapters show datasets that are accessible online, i.e. you don't have to download anything. Most datasets are accessed via the [EUREC⁴A intake catalog](https://github.com/eurec4a/eurec4a-intake), which simply said takes care of the links to datasets in their most recent version.
+The scripts typically contain at minimum how to get a specific dataset and some simple plots of basic quantities. Most chapters include additional information from aircraft flight segments or further EUREC⁴A meta data, sometimes more sophisticated plots, or also a combination of variables from different datasets.
 
 ## How can you run the code?
 In the chapters you will find a rocket icon (<i class="fas fa-rocket"></i>) in the top bar to the right. It provides two interactive ways to run the code: `Binder` and `LiveCode`. In both cases a virtual environment is created for you in the background by a click on the respective link and you don't have to take care of any requirements locally on your machine. Of course you can also run all the code locally as described in {doc}`running_locally`.
@@ -14,16 +14,16 @@ In principle, we anticipate to have at minimum one example script per instrument
 If you miss some information that could be valuable, feel free to check the link on [how to contribute](https://github.com/eurec4a/how_to_eurec4a/blob/master/CONTRIBUTING.md) to this book and make a pull request or open an issue on github if you are short on time. Thanks!
 
 ## Useful links
-A list of links to general information about EUREC4A:
-* [official EUREC4A webpage](http://eurec4a.eu/)
-* EUREC4A overview papers: {cite:t}`Bony:2017` and {cite:t}`Stevens:2021`
-* [eurec4a GitHub repository](https://github.com/eurec4a)
+A list of links to general information about EUREC⁴A:
+* [official EUREC⁴A webpage](http://eurec4a.eu/)
+* EUREC⁴A overview papers: {cite:t}`Bony:2017` and {cite:t}`Stevens:2021`
+* [EUREC⁴A GitHub repository](https://github.com/eurec4a)
 * [AERIS data server](https://observations.ipsl.fr/aeris/eurec4a-data/)
 * [AERIS leaflet](https://observations.ipsl.fr/aeris/eurec4a/Leaflet/index.html)(data visualization)
 
 ## License
 
-The how to EUREC4A book is licensed under:
+The how to EUREC⁴A book is licensed under:
 
 ```{include} LICENSE
 ```

--- a/how_to_eurec4a/merian.md
+++ b/how_to_eurec4a/merian.md
@@ -1,9 +1,9 @@
 # Merian
 
-The [Maria S. Merian](https://www.ldf.uni-hamburg.de/en/merian.html) is one of the research vessel deployed in the Atlantic Ocean during the EUREC4A campaign. The RV was equipped with stabilized Wband and micro rain radars, a water vapor raman lidar, a wind lidar, and a cloud kite for in situ measurements. Radiosondes were launched from the vessel during the entire campaign. All instruments and PIs are listed on the official [eurec4a](http://eurec4a.eu/platforms/rv-maria-s-merian) webpage.
+The [Maria S. Merian](https://www.ldf.uni-hamburg.de/en/merian.html) is one of the research vessel deployed in the Atlantic Ocean during the EUREC⁴A campaign. The RV was equipped with stabilized Wband and micro rain radars, a water vapor raman lidar, a wind lidar, and a cloud kite for in situ measurements. Radiosondes were launched from the vessel during the entire campaign. All instruments and PIs are listed on the official [EUREC⁴A](http://eurec4a.eu/platforms/rv-maria-s-merian) webpage.
 
 
-During EUREC4A Maria S. Merian span a large region of ocean between 60 and 51 degrees W and 14 and 6 degrees N.
+During EUREC⁴A Maria S. Merian span a large region of ocean between 60 and 51 degrees W and 14 and 6 degrees N.
 
 
 ```{figure} merian.jpg

--- a/how_to_eurec4a/netcdf_datatypes.md
+++ b/how_to_eurec4a/netcdf_datatypes.md
@@ -21,7 +21,7 @@ This is not only a bold statement, but is actually asked and discussed by the ne
 This chapter is not exactly about the same topic in the referenced issue, but still has similar roots.
 The relevant part for this discussion is that there is at least netCDF, the **data model** and netCDF, the **persistence format**.
 It is also recognized that there are multiple persistence formats (netCDF3, netCDF4/HDF5, zarr) for the same data model and there are translation layers such as OPeNDAP which can be used as a transport mechanism between the computer on which data is stored and the computer on which data is analyzed.
-We further look at the relevance of the netCDF data model and netCDF persistence format for the EUREC4A datasets.
+We further look at the relevance of the netCDF data model and netCDF persistence format for the EUREC⁴A datasets.
 
 ### The data model(s)
 There are actually a few different ideas of data models around, which share some general ideas.
@@ -43,7 +43,7 @@ It is useful to distinguish between _variables_ and _coordinates_ within the met
 In addition to the existence of _coordinates_, there are more pieces of valuable additional information (think of units, coordinate reference systems, author information etc...).
 Thus we usually want those extra bits to datasets and variables, which can be done by the use of _attributes_.
 
-It turns out that many datasets in the EUREC4A context can be represented very well in this model.
+It turns out that many datasets in the EUREC⁴A context can be represented very well in this model.
 I assume that in many cases when we talk about that a dataset being available in netCDF, what we really care about is that the dataset is organized along this general structure and thus can be accesses _as if it were netCDF_.
 
 ### The storage and transport formats
@@ -91,14 +91,14 @@ Thus, if a dataset should be accessed efficiently from a remote location, someth
 
 ````{margin}
 ```{note}
-Datacenters used by EUREC4A provide data via OPeNDAP include Aeris, NOAA PSL, NOAA NCEI, MPIM RAMADDA and the specMACS macsServer. The How to EUREC4A book makes use of this service to access the various datasets.
+Datacenters used by EUREC⁴A provide data via OPeNDAP include Aeris, NOAA PSL, NOAA NCEI, MPIM RAMADDA and the specMACS macsServer. The How to EUREC⁴A book makes use of this service to access the various datasets.
 ```
 ````
 
 [OPeNDAP](https://www.opendap.org) is a network protocol to access scientific data via network.
 In particular, it uses HTTP as a transport mechanism and defines a way to request subsets of a dataset which is formed along the data model as described above.
 OPeNDAP is thus the go-to method if an existing netCDF dataset should be made available remotely.
-In the context of EUREC4A, most datacenters provide access to uploaded datasets via OPeNDAP.
+In the context of EUREC⁴A, most datacenters provide access to uploaded datasets via OPeNDAP.
 
 OPeNDAP is specified in two versions, namely [version 2](https://www.opendap.org/pdf/ESE-RFC-004v1.2.pdf) and [version 4](https://www.opendap.org/pdf/dap_objects.pdf). 
 However, DAP4 is still a draft since 2004 and the only widely supported version of OPeNDAP is version 2.

--- a/how_to_eurec4a/p3_AXBTs.md
+++ b/how_to_eurec4a/p3_AXBTs.md
@@ -13,7 +13,7 @@ kernelspec:
 
 # Ocean temperatures: AXBTs and SWIFT buoys
 
-During EUREC4A/ATOMIC the P-3 deployed 165 Airborne eXpendable BathyThermographs (AXBTs)
+During EUREC⁴A/ATOMIC the P-3 deployed 165 Airborne eXpendable BathyThermographs (AXBTs)
 to measure profiles of ocean temperature. (These are kind of the oceanic equivalent of
 dropsondes but they don't measure salinity.) Often these were dropped around
 other ocean temperature measurements - for example the autonomous

--- a/how_to_eurec4a/p3_flight_tracks.md
+++ b/how_to_eurec4a/p3_flight_tracks.md
@@ -129,7 +129,7 @@ def to_datetime(dt64):
     return datetime.datetime.utcfromtimestamp((dt64 - epoch) / second)
 ```
 
-Most platforms available from the EUREC4A `intake` catalog have a `tracks` element but
+Most platforms available from the EUREC⁴A `intake` catalog have a `tracks` element but
 we'll use the `flight-level` data instead. We're using `xr.concat()` with one `dask` array per day
 to avoid loading the whole dataset into memory at once.
 

--- a/how_to_eurec4a/p3_humidity_comparison.md
+++ b/how_to_eurec4a/p3_humidity_comparison.md
@@ -13,7 +13,7 @@ kernelspec:
 
 # Humidity comparison: Hygrometer and isotope analyzer
 
-During EUREC4A and ATOMIC the P3 made two _in situ_ measurements of humidity, one  
+During EUREC⁴A and ATOMIC the P3 made two _in situ_ measurements of humidity, one  
 with the normal chilled-mirror hygrometer, and one with a cavity ring down spectrometer.
 The spectrometer's main purpose was to measure isotopes of water vapor but it's
 good for the total humidty as well.

--- a/how_to_eurec4a/p3_wband_radar.md
+++ b/how_to_eurec4a/p3_wband_radar.md
@@ -13,12 +13,12 @@ kernelspec:
 
 # W-band radar example
 
- During EUREC4A and ATOMIC NOAA deployed W-band (94 GHz) radars on both the P-3 aircraft
+ During EUREC⁴A and ATOMIC NOAA deployed W-band (94 GHz) radars on both the P-3 aircraft
  and the ship Ron Brown. The airborne radar was operated with 220 30-meter range gates
  with a dwell time of 0.5 seconds. The minimum detectable reflectivity of -36 dBZ at a range of
  1 km although accurate estimates of Doppler properties require about -30 dBZ at 1 km.
 
-The data are available through the EUREC4A intake catalog.
+The data are available through the EUREC⁴A intake catalog.
 
 ```{code-cell} ipython3
 import datetime

--- a/how_to_eurec4a/p3_wsra.md
+++ b/how_to_eurec4a/p3_wsra.md
@@ -13,7 +13,7 @@ kernelspec:
 
 # WSRA example: surface wave state
 
-During EUREC4A/ATOMIC the P-3 flew with a Wide Swath Radar Altimeter (WSRA),
+During EUREC⁴A/ATOMIC the P-3 flew with a Wide Swath Radar Altimeter (WSRA),
 a digital beam-forming radar altimeter operating at 16 GHz in the Ku band. It
 generates 80 narrow beams spread over 30 deg to produce a topographic map of the
 sea surface waves and their backscattered power. These measurements allow for
@@ -26,7 +26,7 @@ which designed and built the instrument.
 The WSRA also produces rainfall rate estimates from path-integrated attenuation but
 we won't look at those here.
 
-The data are available through the EUREC4A intake catalog.
+The data are available through the EUREC⁴A intake catalog.
 
 ```{code-cell} ipython3
 import xarray as xr

--- a/how_to_eurec4a/pthree.md
+++ b/how_to_eurec4a/pthree.md
@@ -1,12 +1,12 @@
 # NOAA P3 "Miss Piggy"
 
-During EUREC4A and ATOMIC the US agency NOAA operated a Lockheed WP-3D Orion research aircraft
+During EUREC⁴A and ATOMIC the US agency NOAA operated a Lockheed WP-3D Orion research aircraft
 from the island of Barbados during the period Jan 17 - Feb 11 2020. The aircraft,
 known formally as N43RF and informally as "Miss Piggy," is one of two such aircraft
 in NOAA's Hurricane Hunter fleet. (The other is known as "Kermit.")
 
 ATOMIC included a cruise by the NOAA ship Ronald H. Brown (RHB). Both the P-3 and the RHB
-primarily operated east of the EUREC4A area (i.e. east of 57E), nominally upwind,
+primarily operated east of the EUREC⁴A area (i.e. east of 57E), nominally upwind,
 within the "Tradewind Alley" extending eastwards from Barbados towards the
 Northwest Tropical Atlantic Station (NTAS) buoy near 15N, 51W.  Many of the eleven
 P-3 flights included excursions to the location of the RHB and sampling of

--- a/how_to_eurec4a/simulations.md
+++ b/how_to_eurec4a/simulations.md
@@ -13,7 +13,7 @@ kernelspec:
 
 # Simulations
 
-The wealth of EUREC4A observations is increasingly complemented by simulations on different scales and different amount of realism.
+The wealth of EUREC⁴A observations is increasingly complemented by simulations on different scales and different amount of realism.
 The following pages give an overview on some of the details of these simulations and how to access them.
 
 The currently available simulations and their outputs are:

--- a/how_to_eurec4a/specmacs.md
+++ b/how_to_eurec4a/specmacs.md
@@ -14,7 +14,7 @@ kernelspec:
 # specMACS cloudmask
 
 The following script exemplifies the access and usage of specMACS data measured 
-during EUREC4A.
+during EUREC⁴A.
 
 The specMACS sensor consists of hyperspectral image sensors as well as polarization resolving image sensors.
 The hyperspectral image sensors operate in the visible and near infrared (VNIR) and the short-wave infrared (SWIR) range.
@@ -26,7 +26,7 @@ Our plan is to analyze a section of the specMACS cloud mask dataset around the f
 +++
 
 ## Obtaining data
-In order to work with EUREC4A datasets, we'll use the `eurec4a` library to access the datasets and also use `numpy` and `xarray` as our common tools to handle datasets.
+In order to work with EUREC⁴A datasets, we'll use the `eurec4a` library to access the datasets and also use `numpy` and `xarray` as our common tools to handle datasets.
 
 ```{code-cell} ipython3
 import eurec4a

--- a/how_to_eurec4a/unified.md
+++ b/how_to_eurec4a/unified.md
@@ -18,7 +18,7 @@ The HALO UNIFEID dataset is a combination of [HAMP](https://amt.copernicus.org/a
 More information on the dataset can be found at {cite:t}`Konow:2021`. If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
 ## Get data
-* To load the data we first load the EUREC4A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
+* To load the data we first load the EUREC⁴A meta data catalogue. More information on the catalog can be found [here](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue).
 
 ```{code-cell} ipython3
 import eurec4a

--- a/how_to_eurec4a/velox.md
+++ b/how_to_eurec4a/velox.md
@@ -23,7 +23,7 @@ meta = eurec4a.get_meta()
 Markdown(meta["VELOX"]["description"])
 ```
 
-The PI during EUREC4A was Michael Schäfer (University Leipzig). 
+The PI during EUREC⁴A was Michael Schäfer (University Leipzig).
 
 If you have questions or if you would like to use the data for a publication, please don't hesitate to get in contact with the dataset authors as stated in the dataset attributes `contact` or `author`.
 
@@ -32,7 +32,7 @@ No data available for the transfer flights (first and last) and the first local 
 ```
 
 ## Get data
-To load the data we first load the [EUREC4A intake catalog](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue) and list the available datasets from VELOX.  
+To load the data we first load the [EUREC⁴A intake catalog](https://github.com/eurec4a/eurec4a-intake#eurec4a-intake-catalogue) and list the available datasets from VELOX.
 Currently, there is a cloud mask product available.
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Fixes #78 nearly everywhere, except for the GitHub repository's about section.