### PR TITLE
Fix #82

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ dependencies:
   - python>=3.7
   - anaconda
   - cartopy
+  - matplotlib
   - pip
   - pip:
     - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 jupyter-book>=0.13.0 # sphinx-design instead of sphinx-panel
 jupytext
-matplotlib
 numpy
 xarray
 eurec4a>=0.0.4


### PR DESCRIPTION
Moving matplotlib dependency to `environment.yml` so that conda can better keep track of the matplotlib-cartopy version dependencies.