### PR TITLE
Add issue template for dataset requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/dataset--documentation--request.md
+++ b/.github/ISSUE_TEMPLATE/dataset--documentation--request.md
@@ -1,7 +1,7 @@
 ---
 name: Dataset (documentation) request
 about: Suggest a dataset that is missing in the catalog and/or HowTo
-title: ''
+title: '[REQUEST] <Please write a meaningful title here>'
 labels: needs-triage
 assignees: ''
 
@@ -10,18 +10,23 @@ assignees: ''
 <!--Please use this issue template if you like to create a request for a dataset that is currently missing from the data storage and/or the eurec4a-intake catalog and/or the HowTo-EUREC4A book.-->
 
 **Which dataset do you refer to?**
-Please describe in words which dataset you refer to by mentioning the research platform (e.g. P3 aircraft, R/V Meteor, Saildrone) or model (e.g. ICON, AROME), the instrument (e.g. Raman lidar, rain gauge) or model experiment (e.g. Botany, LES) and the quantity of interest (e.g. 2m-temperature, rain rate)
+
+<!-- Please describe in words which dataset you refer to by mentioning the research platform (e.g. P3 aircraft, R/V Meteor, Saildrone) or model (e.g. ICON, AROME), the instrument (e.g. Raman lidar, rain gauge) or model experiment (e.g. Botany, LES) and the quantity of interest (e.g. 2m-temperature, rain rate) -->
 
 **Please indicate all places where you could find the dataset or its description**
+
 - [ ] Datastorage (`link to dataset`) (e.g. [AERIS](https://observations.ipsl.fr/aeris/eurec4a-data/)/Zenodo/...)
 - [ ] [EUREC4A-Intake catalog](https://github.com/eurec4a/eurec4a-intake) entry
 - [ ] [HowTo-EUREC4A book](https://howto.eurec4a.eu)
 
 **What is the current issue**
-A clear and concise description of what you want to happen. E.g., do you miss a particular description of the dataset? Have you heard about the existence of a dataset but couldn't find it anywhere? Do you want to access a dataset, but can't open it?
+
+<!-- A clear and concise description of what you want to happen. E.g., do you miss a particular description of the dataset? Have you heard about the existence of a dataset but couldn't find it anywhere? Do you want to access a dataset, but can't open it? -->
 
 **Do you know who might be responsible for the dataset?**
-Mention the contact person of the dataset if it is known to you (e.g. written in the metadata of the dataset). If the GitHub-handle of the person is known, please mention it here as well.
+
+<!-- Mention the contact person of the dataset if it is known to you (e.g. written in the metadata of the dataset). If the GitHub-handle of the person is known, please mention it here as well. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/dataset--documentation--request.md
+++ b/.github/ISSUE_TEMPLATE/dataset--documentation--request.md
@@ -1,0 +1,27 @@
+---
+name: Dataset (documentation) request
+about: Suggest a dataset that is missing in the catalog and/or HowTo
+title: ''
+labels: needs-triage
+assignees: ''
+
+---
+
+<!--Please use this issue template if you like to create a request for a dataset that is currently missing from the data storage and/or the eurec4a-intake catalog and/or the HowTo-EUREC4A book.-->
+
+**Which dataset do you refer to?**
+Please describe in words which dataset you refer to by mentioning the research platform (e.g. P3 aircraft, R/V Meteor, Saildrone) or model (e.g. ICON, AROME), the instrument (e.g. Raman lidar, rain gauge) or model experiment (e.g. Botany, LES) and the quantity of interest (e.g. 2m-temperature, rain rate)
+
+**Please indicate all places where you could find the dataset or its description**
+-[] Datastorage (`link to dataset`) (e.g. [AERIS](https://observations.ipsl.fr/aeris/eurec4a-data/)/Zenodo/...)
+-[] [EUREC4A-Intake catalog](https://github.com/eurec4a/eurec4a-intake) entry
+-[] [HowTo-EUREC4A book](https://howto.eurec4a.eu)
+
+**What is the current issue**
+A clear and concise description of what you want to happen. E.g., do you miss a particular description of the dataset? Have you heard about the existence of a dataset but couldn't find it anywhere? Do you want to access a dataset, but can't open it?
+
+**Do you know who might be responsible for the dataset?**
+Mention the contact person of the dataset if it is known to you (e.g. written in the metadata of the dataset). If the GitHub-handle of the person is known, please mention it here as well.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/dataset--documentation--request.md
+++ b/.github/ISSUE_TEMPLATE/dataset--documentation--request.md
@@ -13,9 +13,9 @@ assignees: ''
 Please describe in words which dataset you refer to by mentioning the research platform (e.g. P3 aircraft, R/V Meteor, Saildrone) or model (e.g. ICON, AROME), the instrument (e.g. Raman lidar, rain gauge) or model experiment (e.g. Botany, LES) and the quantity of interest (e.g. 2m-temperature, rain rate)
 
 **Please indicate all places where you could find the dataset or its description**
--[] Datastorage (`link to dataset`) (e.g. [AERIS](https://observations.ipsl.fr/aeris/eurec4a-data/)/Zenodo/...)
--[] [EUREC4A-Intake catalog](https://github.com/eurec4a/eurec4a-intake) entry
--[] [HowTo-EUREC4A book](https://howto.eurec4a.eu)
+- [ ] Datastorage (`link to dataset`) (e.g. [AERIS](https://observations.ipsl.fr/aeris/eurec4a-data/)/Zenodo/...)
+- [ ] [EUREC4A-Intake catalog](https://github.com/eurec4a/eurec4a-intake) entry
+- [ ] [HowTo-EUREC4A book](https://howto.eurec4a.eu)
 
 **What is the current issue**
 A clear and concise description of what you want to happen. E.g., do you miss a particular description of the dataset? Have you heard about the existence of a dataset but couldn't find it anywhere? Do you want to access a dataset, but can't open it?

--- a/.github/ISSUE_TEMPLATE/dataset--documentation--request.md
+++ b/.github/ISSUE_TEMPLATE/dataset--documentation--request.md
@@ -21,7 +21,7 @@ assignees: ''
 
 **What is the current issue**
 
-<!-- A clear and concise description of what you want to happen. E.g., do you miss a particular description of the dataset? Have you heard about the existence of a dataset but couldn't find it anywhere? Do you want to access a dataset, but can't open it? -->
+<!-- A clear and concise description of what you want to happen. E.g., do you miss a particular description of the dataset? Have you heard or read about the existence of a dataset but couldn't find it anywhere? Do you want to access a dataset, but can't open it? -->
 
 **Do you know who might be responsible for the dataset?**
 


### PR DESCRIPTION
To make the HowTo-EUREC4A book issue tracker the central platform to communicate about datasets, this is one of several issue templates that shall make it easier for EUREC4A data users to request new documentation about datasets and request the addition of datasets to the eurec4a-intake catalog or the publication of a dataset in general.

The idea is that users try to find out the dataset contact person and that the core-team will contact them via email if they don't have a (known) GitHub-handle and are automatically notified about this issue. This way, it is ensured that dataset providers see the interest in their datasets.