### PR TITLE
always save execution cache

### DIFF
--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -43,6 +43,13 @@ jobs:
       run: |
         conda info
         jupyter-book build -W -n --keep-going  how_to_eurec4a
+    - name: save execution cache
+      uses: actions/cache/save@v3
+      if: always()
+      with:
+        path: |
+          how_to_eurec4a/_build/.jupyter_cache
+        key: ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.ipfs-version }}-${{ matrix.python-version }}
     - name: Archive build artifacts
       if: always()
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR should setup github actions such that the notebook execution cache will always be saved (even in case of errors). To my understanding, jupyterbook will re-execute failed notebooks on the next build, but could reuse successfully executed notebook cells in that case. This should therefore give use a big improvement in average build time.