### PR TITLE
Cache improvements

### DIFF
--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -34,11 +34,14 @@ jobs:
         sudo apt-get install -y wget curl jq
         bash <(curl https://raw.githubusercontent.com/eurec4a/ipfs_tools/main/install_and_run_ipfs.sh) ${{ matrix.ipfs-version }}
     - name: setting up notebook execution cache
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: |
           how_to_eurec4a/_build/.jupyter_cache
-        key: ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.ipfs-version }}-${{ matrix.python-version }}
+        key: ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-
+          ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}-
     - name: build book
       run: |
         conda info
@@ -49,7 +52,7 @@ jobs:
       with:
         path: |
           how_to_eurec4a/_build/.jupyter_cache
-        key: ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.ipfs-version }}-${{ matrix.python-version }}
+        key: ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Archive build artifacts
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -5,13 +5,13 @@ on: [push, pull_request]
 env:
   # Increase this value to reset cache
   CONDA_CACHE_NUMBER: 0
+  PYDEVD_DISABLE_FILE_VALIDATION: 1  # disable warnings that debugger might not work using frozen (i.e. faster-to-load) modules. We'd expect debugging to be done outside of CI, so here it's probably fine to hide it.
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
         ipfs-version: [0.12.0]
     defaults:
       run:
@@ -21,15 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: initialize conda
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: how_to_eurec4a
-        python-version: ${{ matrix.python-version }}
         auto-activate-base: false
         use-mamba: true
         miniforge-variant: Mambaforge
@@ -63,10 +58,10 @@ jobs:
       with:
         path: |
           how_to_eurec4a/_build/.jupyter_cache
-        key: notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-
-          notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-
+          notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ github.run_id }}-
+          notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-
     - name: build book
       run: |
         conda info
@@ -77,7 +72,7 @@ jobs:
       with:
         path: |
           how_to_eurec4a/_build/.jupyter_cache
-        key: notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Archive build artifacts
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -38,10 +38,10 @@ jobs:
       with:
         path: |
           how_to_eurec4a/_build/.jupyter_cache
-        key: ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: ${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-
-          ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}-
+          ${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-
+          ${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-
     - name: build book
       run: |
         conda info
@@ -52,7 +52,7 @@ jobs:
       with:
         path: |
           how_to_eurec4a/_build/.jupyter_cache
-        key: ${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: ${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Archive build artifacts
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -2,6 +2,10 @@ name: buildbook
 
 on: [push, pull_request]
 
+env:
+  # Increase this value to reset cache
+  CONDA_CACHE_NUMBER: 0
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,13 +25,34 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Set up Python modules with conda
+    - name: initialize conda
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: how_to_eurec4a
-        environment-file: environment.yml
         python-version: ${{ matrix.python-version }}
         auto-activate-base: false
+        use-mamba: true
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+    - name: restore conda environment from cache
+      uses: actions/cache/restore@v3
+      with:
+        path: ${{ env.CONDA }}/envs
+        key:
+          conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ env.CONDA_CACHE_NUMBER }}
+      id: conda_cache
+    - name: install conda environment
+      run:
+        mamba env update -n how_to_eurec4a -f environment.yml
+      if: steps.conda_cache.outputs.cache-hit != 'true'
+      id: install_conda_env
+    - name: upload conda environment to cache
+      uses: actions/cache/save@v3
+      if: steps.install_conda_env.outcome == 'success'
+      with:
+        path: ${{ env.CONDA }}/envs
+        key:
+          conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ env.CONDA_CACHE_NUMBER }}
     - name: Install local ipfs node
       run: |
         sudo apt-get update

--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -38,10 +38,10 @@ jobs:
       with:
         path: |
           how_to_eurec4a/_build/.jupyter_cache
-        key: ${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          ${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-
-          ${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-
+          notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-
+          notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-
     - name: build book
       run: |
         conda info
@@ -52,7 +52,7 @@ jobs:
       with:
         path: |
           how_to_eurec4a/_build/.jupyter_cache
-        key: ${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: notebooks-${{ runner.os }}-${{ hashFiles('environment.yml', 'requirements.txt') }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Archive build artifacts
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -77,9 +77,9 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: build
+        name: html
         path: |
-          how_to_eurec4a/_build
+          how_to_eurec4a/_build/html
 
   publish:
     needs: build
@@ -89,8 +89,8 @@ jobs:
       - name: Download compiled book
         uses: actions/download-artifact@v3
         with:
-          name: build
-          path: _build
+          name: html
+          path: html
       - name: set CNAME
         run: |
           printf "howto.eurec4a.eu" > _build/html/CNAME
@@ -98,4 +98,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/html
+          publish_dir: html

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: how_to_eurec4a
 dependencies:
   - python>=3.9
-  - anaconda
   - cartopy
   - matplotlib
   - pip


### PR DESCRIPTION
This PR
* uses the [matching rules for restore_keys](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key) to be able to update the cache and thus fixes #104.
* It also adds caching for the conda environment (which uses mamba now) in a separate cache, thereby speeding up the environment creation.
* I thereby removed the python version from the build matrix, because `mamba update` seems to care only about what's written in `environment.yml` and we likely won't build the thing with different python versions concurrently.
* This change only upload the `html` part of the build output, which speeds up artifact creation and reduces required disk space. I don't think we ever used anything else, so it seems to be a more sensible choice.

In total, a build which fully utilizes the cache is now below 2 minutes or so and this number will often only increase by the amout required to execude the changed notebooks.