### PR TITLE
limit intake versions to <2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy
 xarray
 dask>=2023.2.0
 eurec4a>=0.0.5
-intake[dataframe] # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
+intake[dataframe]<2.0.0 # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
 intake-xarray
 fsspec!=0.9.0 # 0.9.0 has a bug which leads to incomplete reads via HTTP
 ipfsspec>=0.1.4


### PR DESCRIPTION
Intake 2 is not entirely compatible with our current catalogs. For now, we should limit intake to an older version.

closes #107 