### PR TITLE
use eurec4a-intake requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,16 @@
 jupyter-book>=0.13.0 # sphinx-design instead of sphinx-panel
 jupytext
 numpy
-xarray
 dask>=2023.2.0
 eurec4a>=0.0.5
-intake[dataframe] # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
-intake-xarray
 fsspec!=0.9.0 # 0.9.0 has a bug which leads to incomplete reads via HTTP
-ipfsspec>=0.1.4
-requests
 aiohttp
 pydap
 ipyleaflet
 simplification
 colorcet
-zarr>=2.8.3
 datashader
 pybtex-apa-style
 xarray-datatree
 pandas
+-r https://raw.githubusercontent.com/eurec4a/eurec4a-intake/master/requirements.txt


### PR DESCRIPTION
- ensures up-to-date requirements for eurec4a-intake

fixes #107