### PR TITLE
Allow manual trigger of buildbook.yaml

### DIFF
--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -1,6 +1,6 @@
 name: buildbook
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   # Increase this value to reset cache


### PR DESCRIPTION
This PR [adds the capability to trigger the buildbook CI manually](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch).
This would allow us to rerun the book, e.g. in case some external packages have been updated, without the need to change any local code.

I open this PR particularly, because the [FutureWarning of intake-xarray](https://github.com/intake/intake-xarray/issues/145) in our currently hosted version of the book should be fixed by now. It looks a bit ugly right now at e.g. https://howto.eurec4a.eu/icon_les.html