### PR TITLE
eurec4a_mip_submission: change the step to get the access token

### DIFF
--- a/how_to_eurec4a/eurec4a_mip_submission.md
+++ b/how_to_eurec4a/eurec4a_mip_submission.md
@@ -144,7 +144,7 @@ These can be directly written to the DKRZ swift-storage during creation (1), aft
 	To upload the zarr file to swift, an access token needs to be generated first, with
 	
 	```
-	curl -I -X GET https://swift.dkrz.de/auth/v1.0 -H "x-auth-user: <GROUP>:<USERNAME>" -H "x-auth-key: <PASSWORD>" > ~./swiftenv
+	swift auth -A=https://swift.dkrz.de/auth/v1.0 -U <GROUP>:<USERNAME>" -K <PASSWORD>" > ~/.swiftenv
 	```
 
 	where group is `bm1349` for EUREC4A-MIP.


### PR DESCRIPTION
Use swift instead of curl to get the access token. The curl command works, but generates the response in the form
```
HTTP/1.1 200 OK
X-Storage-Url: https://swift.dkrz.de/v1/dkrz_0913c8f3-e7b6-4f94-9221-06880d4ccfea
Content-Type: text/html; charset=UTF-8
X-Auth-Token-Expires: xxxxxxx
X-Auth-Token: dkrz_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Content-Length: 0
...
```
The swift command gives output that can be directly run as a bash script:
```
export OS_STORAGE_URL=https://swift.dkrz.de/v1/dkrz_0913c8f3-e7b6-4f94-9221-06880d4ccfea
export OS_AUTH_TOKEN=dkrz_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```