### PR TITLE
Update TOKEN generation instructions

### DIFF
--- a/how_to_eurec4a/eurec4a_mip_submission.md
+++ b/how_to_eurec4a/eurec4a_mip_submission.md
@@ -159,6 +159,7 @@ These can be directly written to the DKRZ swift-storage during creation (1), aft
 	setenv OS_AUTH_URL " "
 	setenv OS_USERNAME " "
 	setenv OS_PASSWORD " "
+ 	```
 
  	The `OS_AUTH_TOKEN` and `OS_STORAGE_URL` can also be directly requested with:
 	
@@ -188,7 +189,7 @@ These can be directly written to the DKRZ swift-storage during creation (1), aft
 	Please create a new container for each larger dataset (large meaning many files (>1000)). This makes it much easier to delete false datasets, because containers can be much more effeciently deleted on the object store than individual files.
 	```
 
-4. **Creating zarr files locally and transfer them to DKRZ’s filestore via ssh/ftp**
+3. **Creating zarr files locally and transfer them to DKRZ’s filestore via ssh/ftp**
 
 	To transfer zarr files via ftp or ssh, it is advisable to pack zarr files into larger quantities of several GB.
 	If a single tar would be too large and the content shall be distributed across several tar files, it is beneficial to create tar files that are closed in itself, i.e. the data is not split mid-record. This step is needed to allow opening tar-ed zarr files directly without the need of unpacking them.

--- a/how_to_eurec4a/eurec4a_mip_submission.md
+++ b/how_to_eurec4a/eurec4a_mip_submission.md
@@ -195,7 +195,7 @@ These can be directly written to the DKRZ swift-storage during creation (1), aft
 	Please create a new container for each larger dataset (large meaning many files (>1000)). This makes it much easier to delete false datasets, because containers can be much more effeciently deleted on the object store than individual files.
 	```
 
-4. **Creating zarr files locally and transfer them to DKRZ’s filestore via ssh/ftp**
+3. **Creating zarr files locally and transfer them to DKRZ’s filestore via ssh/ftp**
 
 	To transfer zarr files via ftp or ssh, it is advisable to pack zarr files into larger quantities of several GB.
 	If a single tar would be too large and the content shall be distributed across several tar files, it is beneficial to create tar files that are closed in itself, i.e. the data is not split mid-record. This step is needed to allow opening tar-ed zarr files directly without the need of unpacking them.

--- a/how_to_eurec4a/eurec4a_mip_submission.md
+++ b/how_to_eurec4a/eurec4a_mip_submission.md
@@ -141,21 +141,40 @@ These can be directly written to the DKRZ swift-storage during creation (1), aft
 		
 	The upload can be performed with [python-swiftclient](https://platform.swiftstack.com/docs/integration/python-swiftclient.html) which can be installed via `pip install python-swiftclient`.
 
-	To upload the zarr file to swift, an access token needs to be generated first, with
+	To upload the zarr file to swift, an access token needs to be generated first, with e.g. the [swift-token.py provided by DKRZ](https://docs.dkrz.de/_downloads/04e4e2e251f09c129ed9eab88b005fdd/swift-token.py):
+
+	```
+ 	python swift-token.py new
+    # Account: bm1349
+ 	# Username: <DKRZ-USERNAME>
+    # Password: <YOUR-DKRZ-PASSWORD>
+ 	```
+
+ 	This stores the token in ~/.swiftenv which should look like:
+
+	```
+ 	#token expires on: Wed 08. Oct 10:38:35 CEST 2025
+	setenv OS_AUTH_TOKEN dkrz_<TOKEN>
+	setenv OS_STORAGE_URL https://swift.dkrz.de/v1/dkrz_<STORAGEURL>
+	setenv OS_AUTH_URL " "
+	setenv OS_USERNAME " "
+	setenv OS_PASSWORD " "
+
+ 	The `OS_AUTH_TOKEN` and `OS_STORAGE_URL` can also be directly requested with:
 	
 	```
-	curl -I -X GET https://swift.dkrz.de/auth/v1.0 -H "x-auth-user: <GROUP>:<USERNAME>" -H "x-auth-key: <PASSWORD>" > ~./swiftenv
+	curl -I -X GET https://swift.dkrz.de/auth/v1.0 -H "x-auth-user: <GROUP>:<USERNAME>" -H 'x-auth-key: <PASSWORD>' > ~./swiftenv
 	```
 
-	where group is `bm1349` for EUREC4A-MIP.
+	where group is `bm1349` for EUREC4A-MIP, instead of the `swift-token.py` helper script.
 		       
-	The token has to be activated with the following command each time a new terminal has been opened:
+	The token has to be activated with the following command each time a new terminal is opened:
 	
 	```
 	source ~/.swiftenv
 	```
 	
-	Please contact [Hauke Schulz](mailto:haschulz@uw.edu) if you don't have a DKRZ account and otherwise let him know about your username so that it can be added to the project.
+	Please contact [Hauke Schulz](mailto:has@dmi.dk) if you don't have a DKRZ account and otherwise let him know about your username so that it can be added to the project.
 		       
 	The upload itself is performed by
 	
@@ -169,7 +188,7 @@ These can be directly written to the DKRZ swift-storage during creation (1), aft
 	Please create a new container for each larger dataset (large meaning many files (>1000)). This makes it much easier to delete false datasets, because containers can be much more effeciently deleted on the object store than individual files.
 	```
 
-3. **Creating zarr files locally and transfer them to DKRZ’s filestore via ssh/ftp**
+4. **Creating zarr files locally and transfer them to DKRZ’s filestore via ssh/ftp**
 
 	To transfer zarr files via ftp or ssh, it is advisable to pack zarr files into larger quantities of several GB.
 	If a single tar would be too large and the content shall be distributed across several tar files, it is beneficial to create tar files that are closed in itself, i.e. the data is not split mid-record. This step is needed to allow opening tar-ed zarr files directly without the need of unpacking them.

--- a/how_to_eurec4a/eurec4a_mip_submission.md
+++ b/how_to_eurec4a/eurec4a_mip_submission.md
@@ -167,6 +167,12 @@ These can be directly written to the DKRZ swift-storage during creation (1), aft
 	curl -I -X GET https://swift.dkrz.de/auth/v1.0 -H "x-auth-user: <GROUP>:<USERNAME>" -H 'x-auth-key: <PASSWORD>' > ~./swiftenv
 	```
 
+    or alternatively the swift client:
+
+    ```
+    swift auth -A=https://swift.dkrz.de/auth/v1.0 -U <GROUP>:<USERNAME>" -K <PASSWORD>" > ~/.swiftenv
+    ```
+
 	where group is `bm1349` for EUREC4A-MIP, instead of the `swift-token.py` helper script.
 		       
 	The token has to be activated with the following command each time a new terminal is opened:
@@ -189,7 +195,7 @@ These can be directly written to the DKRZ swift-storage during creation (1), aft
 	Please create a new container for each larger dataset (large meaning many files (>1000)). This makes it much easier to delete false datasets, because containers can be much more effeciently deleted on the object store than individual files.
 	```
 
-3. **Creating zarr files locally and transfer them to DKRZ’s filestore via ssh/ftp**
+4. **Creating zarr files locally and transfer them to DKRZ’s filestore via ssh/ftp**
 
 	To transfer zarr files via ftp or ssh, it is advisable to pack zarr files into larger quantities of several GB.
 	If a single tar would be too large and the content shall be distributed across several tar files, it is beneficial to create tar files that are closed in itself, i.e. the data is not split mid-record. This step is needed to allow opening tar-ed zarr files directly without the need of unpacking them.


### PR DESCRIPTION
The token generation for the DKRZ-Swiftstore was not completely correct. The swift-token.py helper script from DKRZ is now linked and described instead of the less user-friendly `curl` method.